### PR TITLE
Bump tree-sitter to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-css"
 description = "css grammar for the tree-sitter parsing library"
-version = "0.19.0"
+version = "0.20.0"
 keywords = ["incremental", "parsing", "css"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-javascript"
@@ -21,7 +21,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = "0.20"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
I have bumped tree-sitter to 0.20. Not sure on the package versioning to accompany if it follows this same number, as some packages follow 0.19 still and others follow 0.20, let me know if this needs to be reverted.

Thanks!