### PR TITLE
Allow `:host` and `:host-context` to take selectors…

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -200,9 +200,9 @@ module.exports = grammar({
     _nth_child_pseudo_class_selector: $ => seq(
       alias(
         choice('nth-child', 'nth-last-child'),
-        $.class_name
+        $.class_name,
       ),
-      alias($.pseudo_class_nth_child_arguments, $.arguments)
+      alias($.pseudo_class_nth_child_arguments, $.arguments),
     ),
 
     pseudo_element_selector: $ => seq(
@@ -257,18 +257,18 @@ module.exports = grammar({
         alias('even', $.plain_value),
         alias('odd', $.plain_value),
         $.integer_value,
-        alias($._nth_functional_notation, $.plain_value)
+        alias($._nth_functional_notation, $.plain_value),
       ),
       optional(
         seq(
           'of',
-          $._selector
-        )
+          $._selector,
+        ),
       ),
-      ')'
+      ')',
     )),
 
-    // An+B notation
+    // An+B notation for `nth-child`/`nth-last-child`.
     _nth_functional_notation: _ => /-?(\d)*n\s*(\+\s*\d+)?/,
 
     pseudo_element_arguments: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -177,11 +177,15 @@ module.exports = grammar({
         // Either a specific pseudo-class that can only accept a selector…
         seq(
           alias(
-            choice('has', 'not', 'is', 'where'),
+            choice('has', 'not', 'is', 'where', 'host', 'host-context'),
             $.class_name,
           ),
           alias($.pseudo_class_with_selector_arguments, $.arguments),
         ),
+        // …or an `nth-child` or `nth-last-child` selector (which can
+        // optionally accept a selector)…
+        $._nth_child_pseudo_class_selector,
+
         // …or any other pseudo-class (for which we'll allow a more diverse set
         // of arguments).
         seq(
@@ -189,6 +193,16 @@ module.exports = grammar({
           optional(alias($.pseudo_class_arguments, $.arguments)),
         ),
       ),
+    ),
+
+    // Only `nth-child`/`nth-last-child`, not `nth-of-type`/`nth-last-of-type`,
+    // allows an optional filtering selector as a parameter.
+    _nth_child_pseudo_class_selector: $ => seq(
+      alias(
+        choice('nth-child', 'nth-last-child'),
+        $.class_name
+      ),
+      alias($.pseudo_class_nth_child_arguments, $.arguments)
     ),
 
     pseudo_element_selector: $ => seq(
@@ -236,6 +250,26 @@ module.exports = grammar({
       sep(',', $._selector),
       ')',
     ),
+
+    pseudo_class_nth_child_arguments: $ => prec(-1, seq(
+      token.immediate('('),
+      choice(
+        alias('even', $.plain_value),
+        alias('odd', $.plain_value),
+        $.integer_value,
+        alias($._nth_functional_notation, $.plain_value)
+      ),
+      optional(
+        seq(
+          'of',
+          $._selector
+        )
+      ),
+      ')'
+    )),
+
+    // An+B notation
+    _nth_functional_notation: _ => /-?(\d)*n\s*(\+\s*\d+)?/,
 
     pseudo_element_arguments: $ => seq(
       token.immediate('('),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -640,6 +640,10 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_nth_child_pseudo_class_selector"
+            },
+            {
               "type": "SEQ",
               "members": [
                 {
@@ -662,6 +666,14 @@
                       {
                         "type": "STRING",
                         "value": "where"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "host"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "host-context"
                       }
                     ]
                   },
@@ -711,6 +723,38 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "_nth_child_pseudo_class_selector": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "nth-child"
+              },
+              {
+                "type": "STRING",
+                "value": "nth-last-child"
+              }
+            ]
+          },
+          "named": true,
+          "value": "class_name"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "pseudo_class_nth_child_arguments"
+          },
+          "named": true,
+          "value": "arguments"
         }
       ]
     },
@@ -1106,6 +1150,87 @@
           "value": ")"
         }
       ]
+    },
+    "pseudo_class_nth_child_arguments": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "STRING",
+              "value": "("
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "even"
+                },
+                "named": true,
+                "value": "plain_value"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "odd"
+                },
+                "named": true,
+                "value": "plain_value"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "integer_value"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_nth_functional_notation"
+                },
+                "named": true,
+                "value": "plain_value"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "of"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_selector"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
+    },
+    "_nth_functional_notation": {
+      "type": "PATTERN",
+      "value": "-?(\\d)*n\\s*(\\+\\s*\\d+)?"
     },
     "pseudo_element_arguments": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2142,6 +2142,10 @@
     "named": false
   },
   {
+    "type": "of",
+    "named": false
+  },
+  {
     "type": "only",
     "named": false
   },

--- a/src/parser.c
+++ b/src/parser.c
@@ -13,11 +13,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 360
+#define STATE_COUNT 371
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 119
+#define SYMBOL_COUNT 129
 #define ALIAS_COUNT 8
-#define TOKEN_COUNT 62
+#define TOKEN_COUNT 70
 #define EXTERNAL_TOKEN_COUNT 3
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -44,112 +44,122 @@ enum ts_symbol_identifiers {
   anon_sym_not = 18,
   anon_sym_is = 19,
   anon_sym_where = 20,
-  anon_sym_COLON_COLON = 21,
-  anon_sym_POUND = 22,
-  anon_sym_LBRACK = 23,
-  anon_sym_EQ = 24,
-  anon_sym_TILDE_EQ = 25,
-  anon_sym_CARET_EQ = 26,
-  anon_sym_PIPE_EQ = 27,
-  anon_sym_STAR_EQ = 28,
-  anon_sym_DOLLAR_EQ = 29,
-  anon_sym_RBRACK = 30,
-  anon_sym_GT = 31,
-  anon_sym_TILDE = 32,
-  anon_sym_PLUS = 33,
-  anon_sym_PIPE = 34,
-  anon_sym_LPAREN = 35,
-  anon_sym_RPAREN = 36,
-  anon_sym_COLON = 37,
-  sym_important = 38,
-  anon_sym_LPAREN2 = 39,
-  anon_sym_and = 40,
-  anon_sym_or = 41,
-  anon_sym_only = 42,
-  anon_sym_selector = 43,
-  aux_sym_color_value_token1 = 44,
-  anon_sym_SQUOTE = 45,
-  aux_sym_string_value_token1 = 46,
-  anon_sym_DQUOTE = 47,
-  aux_sym_string_value_token2 = 48,
-  aux_sym_integer_value_token1 = 49,
-  aux_sym_float_value_token1 = 50,
-  sym_unit = 51,
-  anon_sym_DASH = 52,
-  anon_sym_SLASH = 53,
-  sym_identifier = 54,
-  sym_at_keyword = 55,
-  sym_js_comment = 56,
-  sym_comment = 57,
-  sym_plain_value = 58,
-  sym__descendant_operator = 59,
-  sym__pseudo_class_selector_colon = 60,
-  sym___error_recovery = 61,
-  sym_stylesheet = 62,
-  sym_import_statement = 63,
-  sym_media_statement = 64,
-  sym_charset_statement = 65,
-  sym_namespace_statement = 66,
-  sym_keyframes_statement = 67,
-  sym_keyframe_block_list = 68,
-  sym_keyframe_block = 69,
-  sym_supports_statement = 70,
-  sym_postcss_statement = 71,
-  sym_at_rule = 72,
-  sym_rule_set = 73,
-  sym_selectors = 74,
-  sym_block = 75,
-  sym__selector = 76,
-  sym_universal_selector = 77,
-  sym_class_selector = 78,
-  sym_pseudo_class_selector = 79,
-  sym_pseudo_element_selector = 80,
-  sym_id_selector = 81,
-  sym_attribute_selector = 82,
-  sym_child_selector = 83,
-  sym_descendant_selector = 84,
-  sym_sibling_selector = 85,
-  sym_adjacent_sibling_selector = 86,
-  sym_namespace_selector = 87,
-  sym_pseudo_class_arguments = 88,
-  sym_pseudo_class_with_selector_arguments = 89,
-  sym_pseudo_element_arguments = 90,
-  sym_declaration = 91,
-  sym_last_declaration = 92,
-  sym__query = 93,
-  sym_feature_query = 94,
-  sym_parenthesized_query = 95,
-  sym_binary_query = 96,
-  sym_unary_query = 97,
-  sym_selector_query = 98,
-  sym__value = 99,
-  sym_parenthesized_value = 100,
-  sym_color_value = 101,
-  sym_string_value = 102,
-  sym_integer_value = 103,
-  sym_float_value = 104,
-  sym_grid_value = 105,
-  sym_call_expression = 106,
-  sym_binary_expression = 107,
-  sym_arguments = 108,
-  aux_sym_stylesheet_repeat1 = 109,
-  aux_sym_import_statement_repeat1 = 110,
-  aux_sym_keyframe_block_list_repeat1 = 111,
-  aux_sym_postcss_statement_repeat1 = 112,
-  aux_sym_selectors_repeat1 = 113,
-  aux_sym_block_repeat1 = 114,
-  aux_sym_pseudo_class_arguments_repeat1 = 115,
-  aux_sym_declaration_repeat1 = 116,
-  aux_sym_grid_value_repeat1 = 117,
-  aux_sym_arguments_repeat1 = 118,
-  alias_sym_feature_name = 119,
-  alias_sym_function_name = 120,
-  alias_sym_id_name = 121,
-  alias_sym_keyframes_name = 122,
-  alias_sym_keyword_query = 123,
-  alias_sym_namespace_name = 124,
-  alias_sym_property_name = 125,
-  alias_sym_tag_name = 126,
+  anon_sym_host = 21,
+  anon_sym_host_DASHcontext = 22,
+  anon_sym_nth_DASHchild = 23,
+  anon_sym_nth_DASHlast_DASHchild = 24,
+  anon_sym_COLON_COLON = 25,
+  anon_sym_POUND = 26,
+  anon_sym_LBRACK = 27,
+  anon_sym_EQ = 28,
+  anon_sym_TILDE_EQ = 29,
+  anon_sym_CARET_EQ = 30,
+  anon_sym_PIPE_EQ = 31,
+  anon_sym_STAR_EQ = 32,
+  anon_sym_DOLLAR_EQ = 33,
+  anon_sym_RBRACK = 34,
+  anon_sym_GT = 35,
+  anon_sym_TILDE = 36,
+  anon_sym_PLUS = 37,
+  anon_sym_PIPE = 38,
+  anon_sym_LPAREN = 39,
+  anon_sym_RPAREN = 40,
+  anon_sym_even = 41,
+  anon_sym_odd = 42,
+  anon_sym_of = 43,
+  sym__nth_functional_notation = 44,
+  anon_sym_COLON = 45,
+  sym_important = 46,
+  anon_sym_LPAREN2 = 47,
+  anon_sym_and = 48,
+  anon_sym_or = 49,
+  anon_sym_only = 50,
+  anon_sym_selector = 51,
+  aux_sym_color_value_token1 = 52,
+  anon_sym_SQUOTE = 53,
+  aux_sym_string_value_token1 = 54,
+  anon_sym_DQUOTE = 55,
+  aux_sym_string_value_token2 = 56,
+  aux_sym_integer_value_token1 = 57,
+  aux_sym_float_value_token1 = 58,
+  sym_unit = 59,
+  anon_sym_DASH = 60,
+  anon_sym_SLASH = 61,
+  sym_identifier = 62,
+  sym_at_keyword = 63,
+  sym_js_comment = 64,
+  sym_comment = 65,
+  sym_plain_value = 66,
+  sym__descendant_operator = 67,
+  sym__pseudo_class_selector_colon = 68,
+  sym___error_recovery = 69,
+  sym_stylesheet = 70,
+  sym_import_statement = 71,
+  sym_media_statement = 72,
+  sym_charset_statement = 73,
+  sym_namespace_statement = 74,
+  sym_keyframes_statement = 75,
+  sym_keyframe_block_list = 76,
+  sym_keyframe_block = 77,
+  sym_supports_statement = 78,
+  sym_postcss_statement = 79,
+  sym_at_rule = 80,
+  sym_rule_set = 81,
+  sym_selectors = 82,
+  sym_block = 83,
+  sym__selector = 84,
+  sym_universal_selector = 85,
+  sym_class_selector = 86,
+  sym_pseudo_class_selector = 87,
+  sym__nth_child_pseudo_class_selector = 88,
+  sym_pseudo_element_selector = 89,
+  sym_id_selector = 90,
+  sym_attribute_selector = 91,
+  sym_child_selector = 92,
+  sym_descendant_selector = 93,
+  sym_sibling_selector = 94,
+  sym_adjacent_sibling_selector = 95,
+  sym_namespace_selector = 96,
+  sym_pseudo_class_arguments = 97,
+  sym_pseudo_class_with_selector_arguments = 98,
+  sym_pseudo_class_nth_child_arguments = 99,
+  sym_pseudo_element_arguments = 100,
+  sym_declaration = 101,
+  sym_last_declaration = 102,
+  sym__query = 103,
+  sym_feature_query = 104,
+  sym_parenthesized_query = 105,
+  sym_binary_query = 106,
+  sym_unary_query = 107,
+  sym_selector_query = 108,
+  sym__value = 109,
+  sym_parenthesized_value = 110,
+  sym_color_value = 111,
+  sym_string_value = 112,
+  sym_integer_value = 113,
+  sym_float_value = 114,
+  sym_grid_value = 115,
+  sym_call_expression = 116,
+  sym_binary_expression = 117,
+  sym_arguments = 118,
+  aux_sym_stylesheet_repeat1 = 119,
+  aux_sym_import_statement_repeat1 = 120,
+  aux_sym_keyframe_block_list_repeat1 = 121,
+  aux_sym_postcss_statement_repeat1 = 122,
+  aux_sym_selectors_repeat1 = 123,
+  aux_sym_block_repeat1 = 124,
+  aux_sym_pseudo_class_arguments_repeat1 = 125,
+  aux_sym_declaration_repeat1 = 126,
+  aux_sym_grid_value_repeat1 = 127,
+  aux_sym_arguments_repeat1 = 128,
+  alias_sym_feature_name = 129,
+  alias_sym_function_name = 130,
+  alias_sym_id_name = 131,
+  alias_sym_keyframes_name = 132,
+  alias_sym_keyword_query = 133,
+  alias_sym_namespace_name = 134,
+  alias_sym_property_name = 135,
+  alias_sym_tag_name = 136,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -174,6 +184,10 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_not] = "not",
   [anon_sym_is] = "class_name",
   [anon_sym_where] = "class_name",
+  [anon_sym_host] = "class_name",
+  [anon_sym_host_DASHcontext] = "class_name",
+  [anon_sym_nth_DASHchild] = "class_name",
+  [anon_sym_nth_DASHlast_DASHchild] = "class_name",
   [anon_sym_COLON_COLON] = "::",
   [anon_sym_POUND] = "#",
   [anon_sym_LBRACK] = "[",
@@ -190,6 +204,10 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_PIPE] = "|",
   [anon_sym_LPAREN] = "(",
   [anon_sym_RPAREN] = ")",
+  [anon_sym_even] = "plain_value",
+  [anon_sym_odd] = "plain_value",
+  [anon_sym_of] = "of",
+  [sym__nth_functional_notation] = "plain_value",
   [anon_sym_COLON] = ":",
   [sym_important] = "important",
   [anon_sym_LPAREN2] = "(",
@@ -233,6 +251,7 @@ static const char * const ts_symbol_names[] = {
   [sym_universal_selector] = "universal_selector",
   [sym_class_selector] = "class_selector",
   [sym_pseudo_class_selector] = "pseudo_class_selector",
+  [sym__nth_child_pseudo_class_selector] = "_nth_child_pseudo_class_selector",
   [sym_pseudo_element_selector] = "pseudo_element_selector",
   [sym_id_selector] = "id_selector",
   [sym_attribute_selector] = "attribute_selector",
@@ -243,6 +262,7 @@ static const char * const ts_symbol_names[] = {
   [sym_namespace_selector] = "namespace_selector",
   [sym_pseudo_class_arguments] = "arguments",
   [sym_pseudo_class_with_selector_arguments] = "arguments",
+  [sym_pseudo_class_nth_child_arguments] = "arguments",
   [sym_pseudo_element_arguments] = "arguments",
   [sym_declaration] = "declaration",
   [sym_last_declaration] = "declaration",
@@ -304,6 +324,10 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_not] = anon_sym_not,
   [anon_sym_is] = anon_sym_has,
   [anon_sym_where] = anon_sym_has,
+  [anon_sym_host] = anon_sym_has,
+  [anon_sym_host_DASHcontext] = anon_sym_has,
+  [anon_sym_nth_DASHchild] = anon_sym_has,
+  [anon_sym_nth_DASHlast_DASHchild] = anon_sym_has,
   [anon_sym_COLON_COLON] = anon_sym_COLON_COLON,
   [anon_sym_POUND] = anon_sym_POUND,
   [anon_sym_LBRACK] = anon_sym_LBRACK,
@@ -320,6 +344,10 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_PIPE] = anon_sym_PIPE,
   [anon_sym_LPAREN] = anon_sym_LPAREN,
   [anon_sym_RPAREN] = anon_sym_RPAREN,
+  [anon_sym_even] = sym_plain_value,
+  [anon_sym_odd] = sym_plain_value,
+  [anon_sym_of] = anon_sym_of,
+  [sym__nth_functional_notation] = sym_plain_value,
   [anon_sym_COLON] = anon_sym_COLON,
   [sym_important] = sym_important,
   [anon_sym_LPAREN2] = anon_sym_LPAREN,
@@ -363,6 +391,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_universal_selector] = sym_universal_selector,
   [sym_class_selector] = sym_class_selector,
   [sym_pseudo_class_selector] = sym_pseudo_class_selector,
+  [sym__nth_child_pseudo_class_selector] = sym__nth_child_pseudo_class_selector,
   [sym_pseudo_element_selector] = sym_pseudo_element_selector,
   [sym_id_selector] = sym_id_selector,
   [sym_attribute_selector] = sym_attribute_selector,
@@ -373,6 +402,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_namespace_selector] = sym_namespace_selector,
   [sym_pseudo_class_arguments] = sym_arguments,
   [sym_pseudo_class_with_selector_arguments] = sym_arguments,
+  [sym_pseudo_class_nth_child_arguments] = sym_arguments,
   [sym_pseudo_element_arguments] = sym_arguments,
   [sym_declaration] = sym_declaration,
   [sym_last_declaration] = sym_declaration,
@@ -497,6 +527,22 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [anon_sym_host] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_host_DASHcontext] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_nth_DASHchild] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_nth_DASHlast_DASHchild] = {
+    .visible = true,
+    .named = true,
+  },
   [anon_sym_COLON_COLON] = {
     .visible = true,
     .named = false,
@@ -560,6 +606,22 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_RPAREN] = {
     .visible = true,
     .named = false,
+  },
+  [anon_sym_even] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_odd] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_of] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym__nth_functional_notation] = {
+    .visible = true,
+    .named = true,
   },
   [anon_sym_COLON] = {
     .visible = true,
@@ -733,6 +795,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym__nth_child_pseudo_class_selector] = {
+    .visible = false,
+    .named = true,
+  },
   [sym_pseudo_element_selector] = {
     .visible = true,
     .named = true,
@@ -770,6 +836,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [sym_pseudo_class_with_selector_arguments] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_pseudo_class_nth_child_arguments] = {
     .visible = true,
     .named = true,
   },
@@ -986,11 +1056,11 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [0] = 0,
   [1] = 1,
   [2] = 2,
-  [3] = 2,
-  [4] = 4,
-  [5] = 4,
-  [6] = 2,
-  [7] = 4,
+  [3] = 3,
+  [4] = 2,
+  [5] = 2,
+  [6] = 3,
+  [7] = 3,
   [8] = 8,
   [9] = 9,
   [10] = 10,
@@ -1032,16 +1102,16 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [46] = 46,
   [47] = 47,
   [48] = 48,
-  [49] = 46,
+  [49] = 49,
   [50] = 50,
-  [51] = 51,
+  [51] = 47,
   [52] = 52,
   [53] = 53,
-  [54] = 52,
+  [54] = 54,
   [55] = 55,
-  [56] = 52,
-  [57] = 57,
-  [58] = 58,
+  [56] = 56,
+  [57] = 56,
+  [58] = 56,
   [59] = 59,
   [60] = 60,
   [61] = 61,
@@ -1056,13 +1126,13 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [70] = 70,
   [71] = 71,
   [72] = 72,
-  [73] = 38,
+  [73] = 73,
   [74] = 74,
   [75] = 75,
   [76] = 76,
   [77] = 77,
   [78] = 78,
-  [79] = 79,
+  [79] = 39,
   [80] = 80,
   [81] = 81,
   [82] = 82,
@@ -1095,64 +1165,64 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [109] = 109,
   [110] = 110,
   [111] = 111,
-  [112] = 112,
-  [113] = 96,
-  [114] = 91,
-  [115] = 106,
-  [116] = 111,
+  [112] = 96,
+  [113] = 113,
+  [114] = 114,
+  [115] = 115,
+  [116] = 116,
   [117] = 117,
-  [118] = 118,
-  [119] = 119,
-  [120] = 92,
-  [121] = 93,
-  [122] = 109,
+  [118] = 111,
+  [119] = 108,
+  [120] = 109,
+  [121] = 115,
+  [122] = 122,
   [123] = 123,
-  [124] = 94,
-  [125] = 98,
-  [126] = 100,
-  [127] = 103,
-  [128] = 108,
+  [124] = 124,
+  [125] = 125,
+  [126] = 113,
+  [127] = 127,
+  [128] = 128,
   [129] = 129,
   [130] = 130,
-  [131] = 97,
-  [132] = 99,
-  [133] = 133,
-  [134] = 105,
-  [135] = 110,
-  [136] = 136,
-  [137] = 137,
-  [138] = 138,
-  [139] = 111,
+  [131] = 131,
+  [132] = 100,
+  [133] = 114,
+  [134] = 134,
+  [135] = 97,
+  [136] = 117,
+  [137] = 102,
+  [138] = 106,
+  [139] = 139,
   [140] = 140,
-  [141] = 123,
-  [142] = 90,
-  [143] = 118,
-  [144] = 129,
-  [145] = 119,
-  [146] = 130,
+  [141] = 141,
+  [142] = 134,
+  [143] = 109,
+  [144] = 144,
+  [145] = 128,
+  [146] = 127,
   [147] = 147,
-  [148] = 117,
-  [149] = 149,
-  [150] = 140,
-  [151] = 95,
-  [152] = 147,
-  [153] = 149,
-  [154] = 154,
-  [155] = 140,
-  [156] = 95,
-  [157] = 102,
-  [158] = 158,
-  [159] = 159,
-  [160] = 160,
-  [161] = 161,
-  [162] = 162,
-  [163] = 163,
+  [148] = 148,
+  [149] = 129,
+  [150] = 130,
+  [151] = 131,
+  [152] = 122,
+  [153] = 123,
+  [154] = 116,
+  [155] = 101,
+  [156] = 110,
+  [157] = 144,
+  [158] = 139,
+  [159] = 124,
+  [160] = 125,
+  [161] = 110,
+  [162] = 144,
+  [163] = 99,
   [164] = 164,
   [165] = 165,
   [166] = 166,
   [167] = 167,
-  [168] = 168,
-  [169] = 38,
+  [168] = 39,
+  [169] = 169,
   [170] = 170,
   [171] = 171,
   [172] = 172,
@@ -1164,138 +1234,138 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [178] = 178,
   [179] = 179,
   [180] = 180,
-  [181] = 179,
+  [181] = 181,
   [182] = 182,
-  [183] = 182,
-  [184] = 180,
-  [185] = 40,
-  [186] = 38,
-  [187] = 187,
+  [183] = 183,
+  [184] = 184,
+  [185] = 185,
+  [186] = 186,
+  [187] = 186,
   [188] = 188,
-  [189] = 189,
-  [190] = 190,
-  [191] = 191,
-  [192] = 192,
+  [189] = 185,
+  [190] = 188,
+  [191] = 40,
+  [192] = 39,
   [193] = 193,
-  [194] = 188,
+  [194] = 194,
   [195] = 195,
   [196] = 196,
-  [197] = 80,
-  [198] = 136,
+  [197] = 197,
+  [198] = 198,
   [199] = 199,
-  [200] = 200,
-  [201] = 199,
-  [202] = 137,
-  [203] = 203,
+  [200] = 194,
+  [201] = 201,
+  [202] = 202,
+  [203] = 84,
   [204] = 204,
-  [205] = 159,
+  [205] = 205,
   [206] = 206,
-  [207] = 207,
-  [208] = 208,
-  [209] = 200,
-  [210] = 210,
+  [207] = 140,
+  [208] = 141,
+  [209] = 209,
+  [210] = 169,
   [211] = 211,
-  [212] = 166,
-  [213] = 38,
-  [214] = 163,
-  [215] = 164,
-  [216] = 162,
-  [217] = 165,
-  [218] = 158,
-  [219] = 161,
-  [220] = 168,
-  [221] = 160,
-  [222] = 80,
-  [223] = 167,
-  [224] = 137,
-  [225] = 136,
-  [226] = 167,
-  [227] = 161,
-  [228] = 165,
-  [229] = 163,
-  [230] = 160,
-  [231] = 158,
-  [232] = 166,
-  [233] = 159,
-  [234] = 38,
-  [235] = 164,
-  [236] = 162,
-  [237] = 168,
-  [238] = 238,
-  [239] = 239,
-  [240] = 240,
-  [241] = 241,
-  [242] = 238,
-  [243] = 243,
-  [244] = 239,
-  [245] = 239,
-  [246] = 246,
-  [247] = 246,
-  [248] = 240,
-  [249] = 241,
+  [212] = 212,
+  [213] = 213,
+  [214] = 214,
+  [215] = 206,
+  [216] = 205,
+  [217] = 175,
+  [218] = 167,
+  [219] = 172,
+  [220] = 220,
+  [221] = 39,
+  [222] = 170,
+  [223] = 171,
+  [224] = 224,
+  [225] = 225,
+  [226] = 84,
+  [227] = 227,
+  [228] = 173,
+  [229] = 174,
+  [230] = 166,
+  [231] = 165,
+  [232] = 164,
+  [233] = 140,
+  [234] = 141,
+  [235] = 169,
+  [236] = 39,
+  [237] = 171,
+  [238] = 173,
+  [239] = 174,
+  [240] = 175,
+  [241] = 164,
+  [242] = 165,
+  [243] = 166,
+  [244] = 167,
+  [245] = 170,
+  [246] = 172,
+  [247] = 247,
+  [248] = 248,
+  [249] = 249,
   [250] = 250,
-  [251] = 251,
+  [251] = 247,
   [252] = 252,
-  [253] = 253,
-  [254] = 254,
+  [253] = 249,
+  [254] = 250,
   [255] = 255,
-  [256] = 256,
-  [257] = 257,
-  [258] = 253,
+  [256] = 250,
+  [257] = 248,
+  [258] = 255,
   [259] = 259,
   [260] = 260,
   [261] = 261,
-  [262] = 262,
+  [262] = 259,
   [263] = 263,
   [264] = 264,
   [265] = 265,
-  [266] = 265,
-  [267] = 263,
+  [266] = 266,
+  [267] = 267,
   [268] = 268,
-  [269] = 265,
+  [269] = 269,
   [270] = 270,
-  [271] = 270,
-  [272] = 268,
-  [273] = 273,
-  [274] = 262,
-  [275] = 275,
-  [276] = 105,
-  [277] = 277,
-  [278] = 278,
+  [271] = 271,
+  [272] = 272,
+  [273] = 272,
+  [274] = 271,
+  [275] = 271,
+  [276] = 276,
+  [277] = 276,
+  [278] = 269,
   [279] = 279,
-  [280] = 280,
+  [280] = 268,
   [281] = 281,
-  [282] = 281,
-  [283] = 275,
-  [284] = 281,
-  [285] = 109,
-  [286] = 129,
+  [282] = 282,
+  [283] = 283,
+  [284] = 284,
+  [285] = 106,
+  [286] = 286,
   [287] = 287,
   [288] = 288,
-  [289] = 279,
+  [289] = 284,
   [290] = 290,
   [291] = 291,
   [292] = 292,
-  [293] = 293,
-  [294] = 294,
-  [295] = 295,
-  [296] = 296,
-  [297] = 295,
-  [298] = 295,
-  [299] = 299,
-  [300] = 296,
+  [293] = 287,
+  [294] = 284,
+  [295] = 286,
+  [296] = 113,
+  [297] = 114,
+  [298] = 298,
+  [299] = 140,
+  [300] = 300,
   [301] = 301,
   [302] = 302,
   [303] = 303,
   [304] = 304,
-  [305] = 305,
-  [306] = 136,
-  [307] = 304,
-  [308] = 308,
+  [305] = 300,
+  [306] = 306,
+  [307] = 303,
+  [308] = 303,
   [309] = 309,
-  [310] = 309,
+  [310] = 310,
   [311] = 311,
-  [312] = 302,
+  [312] = 140,
   [313] = 313,
   [314] = 314,
   [315] = 315,
@@ -1303,46 +1373,57 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [317] = 317,
   [318] = 318,
   [319] = 319,
-  [320] = 318,
+  [320] = 320,
   [321] = 313,
-  [322] = 318,
-  [323] = 316,
+  [322] = 314,
+  [323] = 319,
   [324] = 324,
   [325] = 325,
   [326] = 326,
-  [327] = 327,
-  [328] = 316,
-  [329] = 317,
-  [330] = 316,
-  [331] = 317,
-  [332] = 316,
-  [333] = 317,
+  [327] = 325,
+  [328] = 328,
+  [329] = 326,
+  [330] = 325,
+  [331] = 331,
+  [332] = 332,
+  [333] = 333,
   [334] = 334,
   [335] = 335,
-  [336] = 327,
-  [337] = 315,
-  [338] = 325,
-  [339] = 315,
-  [340] = 340,
-  [341] = 314,
-  [342] = 317,
-  [343] = 343,
-  [344] = 344,
+  [336] = 328,
+  [337] = 332,
+  [338] = 333,
+  [339] = 325,
+  [340] = 328,
+  [341] = 325,
+  [342] = 328,
+  [343] = 325,
+  [344] = 324,
   [345] = 345,
-  [346] = 313,
-  [347] = 344,
-  [348] = 340,
-  [349] = 314,
+  [346] = 326,
+  [347] = 347,
+  [348] = 348,
+  [349] = 335,
   [350] = 350,
-  [351] = 340,
-  [352] = 340,
-  [353] = 314,
-  [354] = 340,
-  [355] = 314,
-  [356] = 340,
-  [357] = 314,
-  [358] = 316,
-  [359] = 317,
+  [351] = 347,
+  [352] = 324,
+  [353] = 331,
+  [354] = 354,
+  [355] = 355,
+  [356] = 356,
+  [357] = 357,
+  [358] = 333,
+  [359] = 347,
+  [360] = 332,
+  [361] = 354,
+  [362] = 362,
+  [363] = 347,
+  [364] = 324,
+  [365] = 347,
+  [366] = 324,
+  [367] = 347,
+  [368] = 324,
+  [369] = 328,
+  [370] = 328,
 };
 
 static TSCharacterRange sym_plain_value_character_set_1[] = {
@@ -1360,2989 +1441,3341 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(70);
+      if (eof) ADVANCE(130);
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '$', 38,
-        '&', 86,
-        '\'', 167,
-        '(', 114,
-        ')', 115,
-        '*', 88,
-        '+', 111,
-        ',', 72,
-        '-', 215,
-        '.', 90,
-        '/', 217,
-        ':', 116,
-        ';', 73,
-        '=', 100,
-        '>', 107,
-        '@', 42,
-        '[', 99,
-        ']', 106,
-        '^', 40,
-        'a', 251,
-        'f', 260,
-        'h', 240,
-        'i', 263,
-        'n', 255,
-        'o', 253,
-        's', 245,
-        't', 256,
-        'w', 247,
-        '{', 79,
-        '|', 113,
-        '}', 80,
-        '~', 109,
-        'E', 219,
-        'e', 219,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '$', 47,
+        '&', 144,
+        '\'', 238,
+        '(', 184,
+        ')', 185,
+        '*', 146,
+        '+', 181,
+        ',', 132,
+        '-', 287,
+        '.', 148,
+        '/', 289,
+        ':', 193,
+        ';', 133,
+        '=', 170,
+        '>', 177,
+        '@', 53,
+        'E', 35,
+        '[', 169,
+        ']', 176,
+        '^', 49,
+        'a', 86,
+        'e', 33,
+        'f', 100,
+        'h', 50,
+        'i', 103,
+        'n', 91,
+        'o', 63,
+        's', 67,
+        't', 92,
+        'w', 74,
+        '{', 139,
+        '|', 183,
+        '}', 140,
+        '~', 179,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(67);
+          lookahead == ' ') SKIP(127);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('b' <= lookahead && lookahead <= 'd')) ADVANCE(270);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(188);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('b' <= lookahead && lookahead <= 'd')) ADVANCE(123);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(260);
       END_STATE();
     case 1:
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '%', 212,
-        '\'', 167,
-        '(', 118,
-        ')', 115,
-        '*', 87,
-        '+', 111,
-        ',', 72,
-        '-', 214,
-        '.', 59,
-        '/', 218,
-        ';', 73,
-        '[', 99,
-        '_', 222,
-        '}', 80,
-        'E', 209,
-        'e', 209,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '%', 284,
+        '\'', 238,
+        '(', 195,
+        ')', 185,
+        '*', 145,
+        '+', 181,
+        ',', 132,
+        '-', 286,
+        '.', 119,
+        '/', 290,
+        ';', 133,
+        '[', 169,
+        '_', 294,
+        '}', 140,
+        'E', 280,
+        'e', 280,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(210);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(281);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 2:
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '&', 86,
-        '\'', 167,
-        '(', 118,
-        ')', 115,
-        '*', 87,
-        '+', 32,
-        ',', 72,
-        '-', 31,
-        '.', 90,
-        '/', 23,
-        ':', 37,
-        ';', 73,
-        '[', 99,
-        '_', 222,
-        '}', 80,
-        'E', 221,
-        'e', 221,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '&', 144,
+        '\'', 238,
+        '(', 195,
+        ')', 185,
+        '*', 145,
+        '+', 40,
+        ',', 132,
+        '-', 39,
+        '.', 148,
+        '/', 26,
+        ':', 46,
+        ';', 133,
+        '[', 169,
+        '_', 294,
+        '}', 140,
+        'E', 291,
+        'e', 291,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(2);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 3:
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '\'', 167,
-        '(', 114,
-        ')', 115,
-        '*', 87,
-        '+', 111,
-        ',', 72,
-        '-', 214,
-        '.', 90,
-        '/', 218,
-        ':', 37,
-        ';', 73,
-        '>', 107,
-        '[', 99,
-        '_', 222,
-        '|', 112,
-        '}', 80,
-        '~', 108,
-        'E', 221,
-        'e', 221,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '\'', 238,
+        '(', 184,
+        ')', 185,
+        '*', 145,
+        '+', 181,
+        ',', 132,
+        '-', 286,
+        '.', 148,
+        '/', 290,
+        ':', 46,
+        ';', 133,
+        '>', 177,
+        '[', 169,
+        '_', 294,
+        '|', 182,
+        '}', 140,
+        '~', 178,
+        'E', 291,
+        'e', 291,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(5);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 4:
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '\'', 167,
-        '(', 114,
-        '*', 87,
-        '+', 111,
-        ',', 72,
-        '-', 214,
-        '.', 59,
-        '/', 218,
-        ';', 73,
-        '[', 99,
-        '_', 222,
-        'a', 230,
-        'o', 234,
-        '{', 79,
-        'E', 221,
-        'e', 221,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '\'', 238,
+        '(', 184,
+        '*', 145,
+        '+', 181,
+        ',', 132,
+        '-', 286,
+        '.', 119,
+        '/', 290,
+        ';', 133,
+        '[', 169,
+        '_', 294,
+        'a', 302,
+        'o', 306,
+        '{', 139,
+        'E', 291,
+        'e', 291,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(7);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 5:
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '\'', 167,
-        '(', 118,
-        ')', 115,
-        '*', 87,
-        '+', 111,
-        ',', 72,
-        '-', 214,
-        '.', 90,
-        '/', 218,
-        ':', 37,
-        ';', 73,
-        '>', 107,
-        '[', 99,
-        '_', 222,
-        '|', 112,
-        '}', 80,
-        '~', 108,
-        'E', 221,
-        'e', 221,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '\'', 238,
+        '(', 195,
+        ')', 185,
+        '*', 145,
+        '+', 181,
+        ',', 132,
+        '-', 286,
+        '.', 148,
+        '/', 290,
+        ':', 46,
+        ';', 133,
+        '>', 177,
+        '[', 169,
+        '_', 294,
+        '|', 182,
+        '}', 140,
+        '~', 178,
+        'E', 291,
+        'e', 291,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(5);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 6:
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '\'', 167,
-        '(', 118,
-        ')', 115,
-        '*', 87,
-        '+', 111,
-        ',', 72,
-        '-', 214,
-        '.', 59,
-        '/', 218,
-        ';', 73,
-        '[', 99,
-        '_', 222,
-        '}', 80,
-        'E', 221,
-        'e', 221,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '\'', 238,
+        '(', 195,
+        ')', 185,
+        '*', 145,
+        '+', 181,
+        ',', 132,
+        '-', 286,
+        '.', 119,
+        '/', 290,
+        ';', 133,
+        '[', 169,
+        '_', 294,
+        '}', 140,
+        'E', 291,
+        'e', 291,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 7:
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '\'', 167,
-        '(', 118,
-        '*', 87,
-        '+', 111,
-        ',', 72,
-        '-', 214,
-        '.', 59,
-        '/', 218,
-        ';', 73,
-        '[', 99,
-        '_', 222,
-        'a', 230,
-        'o', 234,
-        '{', 79,
-        'E', 221,
-        'e', 221,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '\'', 238,
+        '(', 195,
+        '*', 145,
+        '+', 181,
+        ',', 132,
+        '-', 286,
+        '.', 119,
+        '/', 290,
+        ';', 133,
+        '[', 169,
+        '_', 294,
+        'a', 302,
+        'o', 306,
+        '{', 139,
+        'E', 291,
+        'e', 291,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(7);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 8:
       ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '\'', 167,
-        '(', 118,
-        '+', 32,
-        '-', 31,
-        '.', 59,
-        '/', 23,
-        ';', 73,
-        '[', 99,
-        '_', 222,
-        'n', 231,
-        'o', 229,
-        's', 226,
-        '{', 79,
-        'E', 221,
-        'e', 221,
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '\'', 238,
+        '(', 195,
+        '+', 40,
+        '-', 39,
+        '.', 119,
+        '/', 26,
+        ';', 133,
+        '[', 169,
+        '_', 294,
+        'n', 303,
+        'o', 301,
+        's', 298,
+        '{', 139,
+        'E', 291,
+        'e', 291,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(8);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 9:
       ADVANCE_MAP(
-        '#', 98,
-        '$', 38,
-        '(', 114,
-        ')', 115,
-        '*', 39,
-        '+', 110,
-        ',', 72,
-        '.', 89,
-        '/', 22,
-        ':', 116,
-        ';', 73,
-        '=', 100,
-        '>', 107,
-        '[', 99,
-        ']', 106,
-        '^', 40,
-        'a', 48,
-        'o', 55,
-        '{', 79,
-        '|', 113,
-        '~', 109,
+        '#', 168,
+        '$', 47,
+        '(', 184,
+        ')', 185,
+        '*', 48,
+        '+', 180,
+        ',', 132,
+        '-', 124,
+        '.', 147,
+        '/', 25,
+        ':', 46,
+        '=', 170,
+        '>', 177,
+        '[', 169,
+        ']', 176,
+        '^', 49,
+        'h', 312,
+        'i', 343,
+        'n', 337,
+        'w', 325,
+        '{', 139,
+        '|', 183,
+        '~', 179,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(11);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('b' <= lookahead && lookahead <= 'f')) ADVANCE(62);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 10:
       ADVANCE_MAP(
-        '#', 98,
-        '$', 38,
-        '(', 114,
-        '*', 88,
-        '+', 110,
-        ',', 72,
-        '-', 213,
-        '.', 89,
-        '/', 217,
-        ':', 37,
-        '=', 100,
-        '>', 107,
-        '[', 99,
-        ']', 106,
-        '^', 40,
-        '|', 113,
-        '~', 109,
+        '#', 168,
+        '$', 47,
+        '(', 184,
+        '*', 146,
+        '+', 180,
+        ',', 132,
+        '-', 285,
+        '.', 147,
+        '/', 289,
+        ':', 46,
+        '=', 170,
+        '>', 177,
+        '[', 169,
+        ']', 176,
+        '^', 49,
+        '|', 183,
+        '~', 179,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(12);
       END_STATE();
     case 11:
       ADVANCE_MAP(
-        '#', 98,
-        '$', 38,
-        ')', 115,
-        '*', 39,
-        '+', 110,
-        ',', 72,
-        '.', 89,
-        '/', 22,
-        ':', 116,
-        ';', 73,
-        '=', 100,
-        '>', 107,
-        '[', 99,
-        ']', 106,
-        '^', 40,
-        'a', 47,
-        'o', 55,
-        '{', 79,
-        '|', 113,
-        '~', 109,
+        '#', 168,
+        '$', 47,
+        ')', 185,
+        '*', 48,
+        '+', 180,
+        ',', 132,
+        '-', 124,
+        '.', 147,
+        '/', 25,
+        ':', 46,
+        '=', 170,
+        '>', 177,
+        '[', 169,
+        ']', 176,
+        '^', 49,
+        'h', 312,
+        'i', 343,
+        'n', 337,
+        'w', 325,
+        '{', 139,
+        '|', 183,
+        '~', 179,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(11);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 12:
       ADVANCE_MAP(
-        '#', 98,
-        '$', 38,
-        '*', 88,
-        '+', 110,
-        ',', 72,
-        '-', 213,
-        '.', 89,
-        '/', 217,
-        ':', 37,
-        '=', 100,
-        '>', 107,
-        '[', 99,
-        ']', 106,
-        '^', 40,
-        '|', 113,
-        '~', 109,
+        '#', 168,
+        '$', 47,
+        '*', 146,
+        '+', 180,
+        ',', 132,
+        '-', 285,
+        '.', 147,
+        '/', 289,
+        ':', 46,
+        '=', 170,
+        '>', 177,
+        '[', 169,
+        ']', 176,
+        '^', 49,
+        '|', 183,
+        '~', 179,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(12);
       END_STATE();
     case 13:
       ADVANCE_MAP(
-        '#', 98,
-        '(', 114,
-        ')', 115,
-        '*', 87,
-        '+', 110,
-        ',', 72,
-        '-', 213,
-        '.', 89,
-        '/', 217,
-        ':', 116,
-        ';', 73,
-        '>', 107,
-        '[', 99,
-        ']', 106,
-        'a', 47,
-        'o', 55,
-        '|', 112,
-        '~', 108,
+        '#', 168,
+        '(', 184,
+        ')', 185,
+        '*', 145,
+        '+', 180,
+        ',', 132,
+        '-', 285,
+        '.', 147,
+        '/', 289,
+        ':', 193,
+        ';', 133,
+        '>', 177,
+        '[', 169,
+        ']', 176,
+        'a', 85,
+        'o', 71,
+        '|', 182,
+        '~', 178,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(14);
       END_STATE();
     case 14:
       ADVANCE_MAP(
-        '#', 98,
-        ')', 115,
-        '*', 87,
-        '+', 110,
-        ',', 72,
-        '-', 213,
-        '.', 89,
-        '/', 217,
-        ':', 116,
-        ';', 73,
-        '>', 107,
-        '[', 99,
-        ']', 106,
-        'a', 47,
-        'o', 55,
-        '|', 112,
-        '~', 108,
+        '#', 168,
+        ')', 185,
+        '*', 145,
+        '+', 180,
+        ',', 132,
+        '-', 285,
+        '.', 147,
+        '/', 289,
+        ':', 193,
+        ';', 133,
+        '>', 177,
+        '[', 169,
+        ']', 176,
+        'a', 85,
+        'o', 71,
+        '|', 182,
+        '~', 178,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(14);
       END_STATE();
     case 15:
       ADVANCE_MAP(
-        '%', 212,
-        '(', 118,
-        '*', 87,
-        '+', 110,
-        '-', 216,
-        '/', 217,
-        ';', 73,
-        'n', 202,
-        'o', 201,
-        's', 198,
+        '%', 284,
+        '(', 195,
+        '*', 145,
+        '+', 180,
+        '-', 288,
+        '/', 289,
+        ';', 133,
+        'n', 273,
+        'o', 272,
+        's', 269,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(18);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
       if (lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 16:
       ADVANCE_MAP(
-        '(', 114,
-        '*', 87,
-        '+', 110,
-        '-', 216,
-        '/', 217,
-        ';', 73,
-        'n', 255,
-        'o', 254,
-        's', 245,
+        '(', 184,
+        '*', 145,
+        '+', 180,
+        '-', 288,
+        '/', 289,
+        ';', 133,
+        'n', 338,
+        'o', 335,
+        's', 324,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(18);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 17:
       ADVANCE_MAP(
-        '(', 118,
-        '*', 87,
-        '+', 110,
-        '-', 216,
-        '/', 217,
-        ';', 73,
-        'n', 255,
-        'o', 254,
-        's', 245,
-        '{', 79,
+        '(', 195,
+        '*', 145,
+        '+', 180,
+        '-', 288,
+        '/', 289,
+        ';', 133,
+        'n', 338,
+        'o', 335,
+        's', 324,
+        '{', 139,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(17);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 18:
       ADVANCE_MAP(
-        '(', 118,
-        '*', 87,
-        '+', 110,
-        '-', 216,
-        '/', 217,
-        ';', 73,
-        'n', 255,
-        'o', 254,
-        's', 245,
+        '(', 195,
+        '*', 145,
+        '+', 180,
+        '-', 288,
+        '/', 289,
+        ';', 133,
+        'n', 338,
+        'o', 335,
+        's', 324,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(18);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 19:
       ADVANCE_MAP(
-        '(', 118,
-        '-', 64,
-        '/', 22,
-        ';', 73,
-        'n', 255,
-        'o', 254,
-        's', 245,
-        '{', 79,
+        '(', 195,
+        '-', 124,
+        '/', 25,
+        ';', 133,
+        'n', 338,
+        'o', 335,
+        's', 324,
+        '{', 139,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(19);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 20:
       ADVANCE_MAP(
-        ')', 115,
-        '*', 87,
-        '+', 110,
-        ',', 72,
-        '-', 213,
-        '/', 217,
-        ';', 73,
-        ']', 106,
+        ')', 185,
+        '*', 145,
+        '+', 180,
+        ',', 132,
+        '-', 285,
+        '/', 289,
+        ';', 133,
+        ']', 176,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(20);
       END_STATE();
     case 21:
       ADVANCE_MAP(
-        ')', 115,
-        '*', 87,
-        '+', 110,
-        ',', 72,
-        '-', 213,
-        '/', 217,
-        ';', 73,
-        ']', 106,
+        ')', 185,
+        '*', 145,
+        '+', 180,
+        ',', 132,
+        '-', 285,
+        '/', 289,
+        ';', 133,
+        ']', 176,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(20);
       if (lookahead == '%' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(212);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(284);
       END_STATE();
     case 22:
-      if (lookahead == '*') ADVANCE(25);
-      if (lookahead == '/') ADVANCE(323);
+      ADVANCE_MAP(
+        ')', 185,
+        ',', 132,
+        '/', 25,
+        ':', 192,
+        ';', 133,
+        'a', 85,
+        'f', 99,
+        'o', 71,
+        't', 92,
+        '{', 139,
+        '}', 140,
+        '+', 121,
+        '-', 121,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(22);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
       END_STATE();
     case 23:
-      if (lookahead == '*') ADVANCE(25);
-      if (lookahead == '/') ADVANCE(320);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(36);
+      if (lookahead == ')') ADVANCE(185);
+      if (lookahead == '/') ADVANCE(25);
+      if (lookahead == 'o') ADVANCE(283);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(24);
+      if (lookahead == '%' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(284);
       END_STATE();
     case 24:
-      if (lookahead == '*') ADVANCE(24);
-      if (lookahead == '/') ADVANCE(324);
-      if (lookahead != 0) ADVANCE(25);
+      if (lookahead == ')') ADVANCE(185);
+      if (lookahead == '/') ADVANCE(25);
+      if (lookahead == 'o') ADVANCE(70);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(24);
       END_STATE();
     case 25:
-      if (lookahead == '*') ADVANCE(24);
-      if (lookahead != 0) ADVANCE(25);
+      if (lookahead == '*') ADVANCE(28);
+      if (lookahead == '/') ADVANCE(409);
       END_STATE();
     case 26:
-      if (lookahead == '-') ADVANCE(64);
-      if (lookahead == '/') ADVANCE(22);
-      if (lookahead == 'h') ADVANCE(240);
-      if (lookahead == 'i') ADVANCE(263);
-      if (lookahead == 'n') ADVANCE(255);
-      if (lookahead == 'w') ADVANCE(247);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(26);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+      if (lookahead == '*') ADVANCE(28);
+      if (lookahead == '/') ADVANCE(406);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(45);
       END_STATE();
     case 27:
-      if (lookahead == '-') ADVANCE(64);
-      if (lookahead == '/') ADVANCE(22);
+      if (lookahead == '*') ADVANCE(27);
+      if (lookahead == '/') ADVANCE(410);
+      if (lookahead != 0) ADVANCE(28);
+      END_STATE();
+    case 28:
+      if (lookahead == '*') ADVANCE(27);
+      if (lookahead != 0) ADVANCE(28);
+      END_STATE();
+    case 29:
+      if (lookahead == '+') ADVANCE(121);
+      if (lookahead == '-') ADVANCE(88);
+      if (lookahead == '/') ADVANCE(25);
+      if (lookahead == 'e') ADVANCE(115);
+      if (lookahead == 'n') ADVANCE(190);
+      if (lookahead == 'o') ADVANCE(62);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(28);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(62);
+          lookahead == ' ') SKIP(29);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(261);
+      END_STATE();
+    case 30:
+      if (lookahead == '-') ADVANCE(54);
+      END_STATE();
+    case 31:
+      if (lookahead == '-') ADVANCE(124);
+      if (lookahead == '/') ADVANCE(25);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(32);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(123);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(270);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(356);
       if (('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 28:
-      if (lookahead == '-') ADVANCE(64);
-      if (lookahead == '/') ADVANCE(22);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(28);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 29:
-      if (lookahead == '-') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(193);
-      END_STATE();
-    case 30:
-      if (lookahead == '-') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(155);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(165);
-      END_STATE();
-    case 31:
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == '/') ADVANCE(65);
-      if (lookahead == '-' ||
-          lookahead == '_') ADVANCE(222);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(221);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 32:
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(29);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (lookahead == '-') ADVANCE(124);
+      if (lookahead == '/') ADVANCE(25);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(32);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 33:
-      if (lookahead == '/') ADVANCE(22);
-      if (lookahead == 'f') ADVANCE(56);
-      if (lookahead == 't') ADVANCE(51);
-      if (lookahead == '}') ADVANCE(80);
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(61);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(33);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
+      if (lookahead == '-') ADVANCE(120);
+      if (lookahead == 'v') ADVANCE(68);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(266);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
       END_STATE();
     case 34:
-      if (lookahead == '/') ADVANCE(22);
-      if (lookahead == '{') ADVANCE(79);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(34);
+      if (lookahead == '-') ADVANCE(120);
+      if (lookahead == 'v') ADVANCE(68);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(265);
       END_STATE();
     case 35:
-      if (lookahead == '/') ADVANCE(22);
-      if (lookahead == '{') ADVANCE(79);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(34);
-      if (lookahead == '%' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(212);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(266);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
       END_STATE();
     case 36:
-      if (lookahead == '/') ADVANCE(65);
-      if (lookahead == '-' ||
-          lookahead == '_') ADVANCE(36);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(325);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(265);
       END_STATE();
     case 37:
-      if (lookahead == ':') ADVANCE(97);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(226);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(235);
       END_STATE();
     case 38:
-      if (lookahead == '=') ADVANCE(105);
+      if (lookahead == '-') ADVANCE(57);
       END_STATE();
     case 39:
-      if (lookahead == '=') ADVANCE(104);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(125);
+      if (lookahead == '-' ||
+          lookahead == '_') ADVANCE(294);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(291);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 40:
-      if (lookahead == '=') ADVANCE(102);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(36);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       END_STATE();
     case 41:
-      if (lookahead == 'a') ADVANCE(49);
+      if (lookahead == '/') ADVANCE(25);
+      if (lookahead == '{') ADVANCE(139);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(41);
       END_STATE();
     case 42:
-      if (lookahead == 'c') ADVANCE(290);
-      if (lookahead == 'i') ADVANCE(292);
-      if (lookahead == 'k') ADVANCE(280);
-      if (lookahead == 'm') ADVANCE(281);
-      if (lookahead == 'n') ADVANCE(275);
-      if (lookahead == 's') ADVANCE(315);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+      if (lookahead == '/') ADVANCE(25);
+      if (lookahead == '{') ADVANCE(139);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(41);
+      if (lookahead == '%' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(284);
       END_STATE();
     case 43:
-      if (lookahead == 'd') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(25);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(43);
       END_STATE();
     case 44:
-      if (lookahead == 'i') ADVANCE(45);
+      if (lookahead == '/') ADVANCE(25);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(43);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(123);
       END_STATE();
     case 45:
-      if (lookahead == 'm') ADVANCE(53);
+      if (lookahead == '/') ADVANCE(125);
+      if (lookahead == '-' ||
+          lookahead == '_') ADVANCE(45);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(411);
       END_STATE();
     case 46:
-      if (lookahead == 'm') ADVANCE(81);
+      if (lookahead == ':') ADVANCE(167);
       END_STATE();
     case 47:
-      if (lookahead == 'n') ADVANCE(43);
+      if (lookahead == '=') ADVANCE(175);
       END_STATE();
     case 48:
-      if (lookahead == 'n') ADVANCE(43);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(63);
+      if (lookahead == '=') ADVANCE(174);
       END_STATE();
     case 49:
-      if (lookahead == 'n') ADVANCE(58);
+      if (lookahead == '=') ADVANCE(172);
       END_STATE();
     case 50:
-      if (lookahead == 'o') ADVANCE(54);
+      if (lookahead == 'a') ADVANCE(104);
+      if (lookahead == 'o') ADVANCE(105);
       END_STATE();
     case 51:
-      if (lookahead == 'o') ADVANCE(83);
+      if (lookahead == 'a') ADVANCE(106);
       END_STATE();
     case 52:
-      if (lookahead == 'o') ADVANCE(46);
+      if (lookahead == 'a') ADVANCE(90);
       END_STATE();
     case 53:
-      if (lookahead == 'p') ADVANCE(50);
+      if (lookahead == 'c') ADVANCE(376);
+      if (lookahead == 'i') ADVANCE(378);
+      if (lookahead == 'k') ADVANCE(366);
+      if (lookahead == 'm') ADVANCE(367);
+      if (lookahead == 'n') ADVANCE(361);
+      if (lookahead == 's') ADVANCE(401);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
       END_STATE();
     case 54:
-      if (lookahead == 'r') ADVANCE(57);
+      if (lookahead == 'c') ADVANCE(73);
+      if (lookahead == 'l') ADVANCE(51);
       END_STATE();
     case 55:
-      if (lookahead == 'r') ADVANCE(122);
+      if (lookahead == 'c') ADVANCE(114);
       END_STATE();
     case 56:
-      if (lookahead == 'r') ADVANCE(52);
+      if (lookahead == 'c') ADVANCE(94);
       END_STATE();
     case 57:
-      if (lookahead == 't') ADVANCE(41);
+      if (lookahead == 'c') ADVANCE(75);
       END_STATE();
     case 58:
-      if (lookahead == 't') ADVANCE(117);
+      if (lookahead == 'd') ADVANCE(196);
       END_STATE();
     case 59:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(192);
+      if (lookahead == 'd') ADVANCE(187);
       END_STATE();
     case 60:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(193);
+      if (lookahead == 'd') ADVANCE(163);
       END_STATE();
     case 61:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
+      if (lookahead == 'd') ADVANCE(165);
       END_STATE();
     case 62:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(63);
+      if (lookahead == 'd') ADVANCE(59);
       END_STATE();
     case 63:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(165);
+      if (lookahead == 'd') ADVANCE(59);
+      if (lookahead == 'f') ADVANCE(188);
+      if (lookahead == 'n') ADVANCE(79);
+      if (lookahead == 'r') ADVANCE(198);
       END_STATE();
     case 64:
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+      if (lookahead == 'e') ADVANCE(55);
       END_STATE();
     case 65:
-      if ((!eof && set_contains(sym_plain_value_character_set_1, 10, lookahead))) ADVANCE(36);
+      if (lookahead == 'e') ADVANCE(157);
       END_STATE();
     case 66:
-      if ((!eof && set_contains(sym_plain_value_character_set_1, 10, lookahead))) ADVANCE(325);
+      if (lookahead == 'e') ADVANCE(116);
       END_STATE();
     case 67:
-      if (eof) ADVANCE(70);
-      ADVANCE_MAP(
-        '!', 44,
-        '"', 177,
-        '#', 98,
-        '$', 38,
-        '&', 86,
-        '\'', 167,
-        '(', 118,
-        ')', 115,
-        '*', 88,
-        '+', 111,
-        ',', 72,
-        '-', 215,
-        '.', 90,
-        '/', 217,
-        ':', 116,
-        ';', 73,
-        '=', 100,
-        '>', 107,
-        '@', 42,
-        '[', 99,
-        ']', 106,
-        '^', 40,
-        'a', 252,
-        'f', 261,
-        'h', 240,
-        'i', 263,
-        'n', 255,
-        'o', 253,
-        's', 245,
-        't', 256,
-        'w', 247,
-        '{', 79,
-        '|', 113,
-        '}', 80,
-        '~', 109,
-        'E', 220,
-        'e', 220,
-      );
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(67);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+      if (lookahead == 'e') ADVANCE(81);
       END_STATE();
     case 68:
-      if (eof) ADVANCE(70);
-      ADVANCE_MAP(
-        '"', 177,
-        '#', 98,
-        '&', 86,
-        '\'', 167,
-        '(', 114,
-        ')', 115,
-        '*', 87,
-        '+', 110,
-        ',', 72,
-        '-', 64,
-        '.', 89,
-        '/', 22,
-        ':', 116,
-        ';', 73,
-        '>', 107,
-        '@', 42,
-        '[', 99,
-        ']', 106,
-        '{', 79,
-        '|', 112,
-        '}', 80,
-        '~', 108,
-      );
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(69);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+      if (lookahead == 'e') ADVANCE(87);
       END_STATE();
     case 69:
-      if (eof) ADVANCE(70);
-      ADVANCE_MAP(
-        '"', 177,
-        '#', 98,
-        '&', 86,
-        '\'', 167,
-        ')', 115,
-        '*', 87,
-        '+', 110,
-        ',', 72,
-        '-', 64,
-        '.', 89,
-        '/', 22,
-        ':', 116,
-        ';', 73,
-        '>', 107,
-        '@', 42,
-        '[', 99,
-        ']', 106,
-        '{', 79,
-        '|', 112,
-        '}', 80,
-        '~', 108,
-      );
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(69);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+      if (lookahead == 'e') ADVANCE(102);
       END_STATE();
     case 70:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == 'f') ADVANCE(188);
       END_STATE();
     case 71:
-      ACCEPT_TOKEN(anon_sym_ATimport);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+      if (lookahead == 'f') ADVANCE(188);
+      if (lookahead == 'r') ADVANCE(198);
       END_STATE();
     case 72:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead == 'h') ADVANCE(30);
       END_STATE();
     case 73:
-      ACCEPT_TOKEN(anon_sym_SEMI);
+      if (lookahead == 'h') ADVANCE(77);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(anon_sym_ATmedia);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+      if (lookahead == 'h') ADVANCE(69);
       END_STATE();
     case 75:
-      ACCEPT_TOKEN(anon_sym_ATcharset);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+      if (lookahead == 'h') ADVANCE(78);
       END_STATE();
     case 76:
-      ACCEPT_TOKEN(anon_sym_ATnamespace);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+      if (lookahead == 'i') ADVANCE(83);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(anon_sym_ATkeyframes);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+      if (lookahead == 'i') ADVANCE(80);
       END_STATE();
     case 78:
-      ACCEPT_TOKEN(aux_sym_keyframes_statement_token1);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+      if (lookahead == 'i') ADVANCE(82);
       END_STATE();
     case 79:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == 'l') ADVANCE(117);
       END_STATE();
     case 80:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead == 'l') ADVANCE(60);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(sym_from);
+      if (lookahead == 'l') ADVANCE(64);
       END_STATE();
     case 82:
-      ACCEPT_TOKEN(sym_from);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+      if (lookahead == 'l') ADVANCE(61);
       END_STATE();
     case 83:
-      ACCEPT_TOKEN(sym_to);
+      if (lookahead == 'm') ADVANCE(97);
       END_STATE();
     case 84:
-      ACCEPT_TOKEN(sym_to);
+      if (lookahead == 'm') ADVANCE(141);
+      END_STATE();
+    case 85:
+      if (lookahead == 'n') ADVANCE(58);
+      END_STATE();
+    case 86:
+      if (lookahead == 'n') ADVANCE(58);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
+      END_STATE();
+    case 87:
+      if (lookahead == 'n') ADVANCE(186);
+      END_STATE();
+    case 88:
+      if (lookahead == 'n') ADVANCE(190);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(261);
+      END_STATE();
+    case 89:
+      if (lookahead == 'n') ADVANCE(113);
+      END_STATE();
+    case 90:
+      if (lookahead == 'n') ADVANCE(109);
+      END_STATE();
+    case 91:
+      if (lookahead == 'o') ADVANCE(107);
+      if (lookahead == 't') ADVANCE(72);
+      END_STATE();
+    case 92:
+      if (lookahead == 'o') ADVANCE(142);
+      END_STATE();
+    case 93:
+      if (lookahead == 'o') ADVANCE(84);
+      END_STATE();
+    case 94:
+      if (lookahead == 'o') ADVANCE(89);
+      END_STATE();
+    case 95:
+      if (lookahead == 'o') ADVANCE(101);
+      END_STATE();
+    case 96:
+      if (lookahead == 'o') ADVANCE(98);
+      END_STATE();
+    case 97:
+      if (lookahead == 'p') ADVANCE(95);
+      END_STATE();
+    case 98:
+      if (lookahead == 'r') ADVANCE(204);
+      END_STATE();
+    case 99:
+      if (lookahead == 'r') ADVANCE(93);
+      END_STATE();
+    case 100:
+      if (lookahead == 'r') ADVANCE(93);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
+      END_STATE();
+    case 101:
+      if (lookahead == 'r') ADVANCE(112);
+      END_STATE();
+    case 102:
+      if (lookahead == 'r') ADVANCE(65);
+      END_STATE();
+    case 103:
+      if (lookahead == 's') ADVANCE(155);
+      END_STATE();
+    case 104:
+      if (lookahead == 's') ADVANCE(149);
+      END_STATE();
+    case 105:
+      if (lookahead == 's') ADVANCE(108);
+      END_STATE();
+    case 106:
+      if (lookahead == 's') ADVANCE(111);
+      END_STATE();
+    case 107:
+      if (lookahead == 't') ADVANCE(151);
+      END_STATE();
+    case 108:
+      if (lookahead == 't') ADVANCE(160);
+      END_STATE();
+    case 109:
+      if (lookahead == 't') ADVANCE(194);
+      END_STATE();
+    case 110:
+      if (lookahead == 't') ADVANCE(161);
+      END_STATE();
+    case 111:
+      if (lookahead == 't') ADVANCE(38);
+      END_STATE();
+    case 112:
+      if (lookahead == 't') ADVANCE(52);
+      END_STATE();
+    case 113:
+      if (lookahead == 't') ADVANCE(66);
+      END_STATE();
+    case 114:
+      if (lookahead == 't') ADVANCE(96);
+      END_STATE();
+    case 115:
+      if (lookahead == 'v') ADVANCE(68);
+      END_STATE();
+    case 116:
+      if (lookahead == 'x') ADVANCE(110);
+      END_STATE();
+    case 117:
+      if (lookahead == 'y') ADVANCE(200);
+      END_STATE();
+    case 118:
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(118);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(191);
+      END_STATE();
+    case 119:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(264);
+      END_STATE();
+    case 120:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(265);
+      END_STATE();
+    case 121:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
+      END_STATE();
+    case 122:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(235);
+      END_STATE();
+    case 123:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
+      END_STATE();
+    case 124:
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
-    case 85:
-      ACCEPT_TOKEN(anon_sym_ATsupports);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
+    case 125:
+      if ((!eof && set_contains(sym_plain_value_character_set_1, 10, lookahead))) ADVANCE(45);
+      END_STATE();
+    case 126:
+      if ((!eof && set_contains(sym_plain_value_character_set_1, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 127:
+      if (eof) ADVANCE(130);
+      ADVANCE_MAP(
+        '!', 76,
+        '"', 248,
+        '#', 168,
+        '$', 47,
+        '&', 144,
+        '\'', 238,
+        '(', 195,
+        ')', 185,
+        '*', 146,
+        '+', 181,
+        ',', 132,
+        '-', 287,
+        '.', 148,
+        '/', 289,
+        ':', 193,
+        ';', 133,
+        '=', 170,
+        '>', 177,
+        '@', 53,
+        'E', 36,
+        '[', 169,
+        ']', 176,
+        '^', 49,
+        'a', 85,
+        'e', 34,
+        'f', 99,
+        'h', 50,
+        'i', 103,
+        'n', 91,
+        'o', 63,
+        's', 67,
+        't', 92,
+        'w', 74,
+        '{', 139,
+        '|', 183,
+        '}', 140,
+        '~', 179,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(127);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
+      END_STATE();
+    case 128:
+      if (eof) ADVANCE(130);
+      ADVANCE_MAP(
+        '"', 248,
+        '#', 168,
+        '&', 144,
+        '\'', 238,
+        '(', 184,
+        ')', 185,
+        '*', 145,
+        '+', 180,
+        ',', 132,
+        '-', 124,
+        '.', 147,
+        '/', 25,
+        ':', 193,
+        ';', 133,
+        '>', 177,
+        '@', 53,
+        '[', 169,
+        ']', 176,
+        '{', 139,
+        '|', 182,
+        '}', 140,
+        '~', 178,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(129);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
-    case 86:
+    case 129:
+      if (eof) ADVANCE(130);
+      ADVANCE_MAP(
+        '"', 248,
+        '#', 168,
+        '&', 144,
+        '\'', 238,
+        ')', 185,
+        '*', 145,
+        '+', 180,
+        ',', 132,
+        '-', 124,
+        '.', 147,
+        '/', 25,
+        ':', 193,
+        ';', 133,
+        '>', 177,
+        '@', 53,
+        '[', 169,
+        ']', 176,
+        '{', 139,
+        '|', 182,
+        '}', 140,
+        '~', 178,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(129);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(anon_sym_ATimport);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(anon_sym_SEMI);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(anon_sym_ATmedia);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(anon_sym_ATcharset);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(anon_sym_ATnamespace);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(anon_sym_ATkeyframes);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 138:
+      ACCEPT_TOKEN(aux_sym_keyframes_statement_token1);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      END_STATE();
+    case 140:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(sym_from);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(sym_to);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(anon_sym_ATsupports);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 144:
       ACCEPT_TOKEN(sym_nesting_selector);
       END_STATE();
-    case 87:
+    case 145:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 88:
+    case 146:
       ACCEPT_TOKEN(anon_sym_STAR);
-      if (lookahead == '=') ADVANCE(104);
+      if (lookahead == '=') ADVANCE(174);
       END_STATE();
-    case 89:
+    case 147:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 90:
+    case 148:
       ACCEPT_TOKEN(anon_sym_DOT);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(192);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(264);
       END_STATE();
-    case 91:
+    case 149:
+      ACCEPT_TOKEN(anon_sym_has);
+      END_STATE();
+    case 150:
       ACCEPT_TOKEN(anon_sym_has);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
-    case 92:
+    case 151:
       ACCEPT_TOKEN(anon_sym_not);
-      if (lookahead == '%') ADVANCE(212);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(anon_sym_not);
+      if (lookahead == '%') ADVANCE(284);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
-    case 93:
+    case 153:
       ACCEPT_TOKEN(anon_sym_not);
-      if (lookahead == '/') ADVANCE(66);
+      if (lookahead == '/') ADVANCE(126);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
       END_STATE();
-    case 94:
+    case 154:
       ACCEPT_TOKEN(anon_sym_not);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
-    case 95:
+    case 155:
+      ACCEPT_TOKEN(anon_sym_is);
+      END_STATE();
+    case 156:
       ACCEPT_TOKEN(anon_sym_is);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
-    case 96:
+    case 157:
+      ACCEPT_TOKEN(anon_sym_where);
+      END_STATE();
+    case 158:
       ACCEPT_TOKEN(anon_sym_where);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(anon_sym_COLON_COLON);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(anon_sym_POUND);
-      END_STATE();
-    case 99:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      END_STATE();
-    case 100:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(anon_sym_TILDE_EQ);
-      END_STATE();
-    case 102:
-      ACCEPT_TOKEN(anon_sym_CARET_EQ);
-      END_STATE();
-    case 103:
-      ACCEPT_TOKEN(anon_sym_PIPE_EQ);
-      END_STATE();
-    case 104:
-      ACCEPT_TOKEN(anon_sym_STAR_EQ);
-      END_STATE();
-    case 105:
-      ACCEPT_TOKEN(anon_sym_DOLLAR_EQ);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(anon_sym_GT);
-      END_STATE();
-    case 108:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      END_STATE();
-    case 109:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      if (lookahead == '=') ADVANCE(101);
-      END_STATE();
-    case 110:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(29);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      END_STATE();
-    case 113:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '=') ADVANCE(103);
-      END_STATE();
-    case 114:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    case 116:
-      ACCEPT_TOKEN(anon_sym_COLON);
-      if (lookahead == ':') ADVANCE(97);
-      END_STATE();
-    case 117:
-      ACCEPT_TOKEN(sym_important);
-      END_STATE();
-    case 118:
-      ACCEPT_TOKEN(anon_sym_LPAREN2);
-      END_STATE();
-    case 119:
-      ACCEPT_TOKEN(anon_sym_and);
-      END_STATE();
-    case 120:
-      ACCEPT_TOKEN(anon_sym_and);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 121:
-      ACCEPT_TOKEN(anon_sym_and);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 122:
-      ACCEPT_TOKEN(anon_sym_or);
-      END_STATE();
-    case 123:
-      ACCEPT_TOKEN(anon_sym_or);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 124:
-      ACCEPT_TOKEN(anon_sym_or);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 125:
-      ACCEPT_TOKEN(anon_sym_only);
-      if (lookahead == '%') ADVANCE(212);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 126:
-      ACCEPT_TOKEN(anon_sym_only);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 127:
-      ACCEPT_TOKEN(anon_sym_only);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 128:
-      ACCEPT_TOKEN(anon_sym_selector);
-      if (lookahead == '%') ADVANCE(212);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 129:
-      ACCEPT_TOKEN(anon_sym_selector);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 130:
-      ACCEPT_TOKEN(anon_sym_selector);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 131:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      END_STATE();
-    case 132:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '-') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(193);
-      END_STATE();
-    case 133:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '-') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(131);
-      END_STATE();
-    case 134:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '-') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(147);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(157);
-      END_STATE();
-    case 135:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '-') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(149);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(159);
-      END_STATE();
-    case 136:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '-') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(152);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(161);
-      END_STATE();
-    case 137:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '-') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(154);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(163);
-      END_STATE();
-    case 138:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(29);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
-      END_STATE();
-    case 139:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(132);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(131);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(138);
-      END_STATE();
-    case 140:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(134);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(159);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(141);
-      END_STATE();
-    case 141:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(133);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(139);
-      END_STATE();
-    case 142:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(135);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(161);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(140);
-      END_STATE();
-    case 143:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(136);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(163);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(142);
-      END_STATE();
-    case 144:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(193);
-      END_STATE();
-    case 145:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(194);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 146:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(145);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(166);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 147:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(131);
-      END_STATE();
-    case 148:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(150);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(158);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 149:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(147);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(157);
-      END_STATE();
-    case 150:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(146);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(156);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(148);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(160);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 152:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(149);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(159);
-      END_STATE();
-    case 153:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(151);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(162);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 154:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(152);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(161);
-      END_STATE();
-    case 155:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(154);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(163);
-      END_STATE();
-    case 156:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(166);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 157:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(131);
-      END_STATE();
-    case 158:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(156);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 159:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      ACCEPT_TOKEN(anon_sym_host);
+      if (lookahead == '-') ADVANCE(314);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(157);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 160:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(158);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+      ACCEPT_TOKEN(anon_sym_host);
+      if (lookahead == '-') ADVANCE(56);
       END_STATE();
     case 161:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(159);
+      ACCEPT_TOKEN(anon_sym_host_DASHcontext);
       END_STATE();
     case 162:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(160);
+      ACCEPT_TOKEN(anon_sym_host_DASHcontext);
       if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 163:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(161);
+      ACCEPT_TOKEN(anon_sym_nth_DASHchild);
       END_STATE();
     case 164:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(162);
+      ACCEPT_TOKEN(anon_sym_nth_DASHchild);
       if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 165:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(163);
+      ACCEPT_TOKEN(anon_sym_nth_DASHlast_DASHchild);
       END_STATE();
     case 166:
-      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      ACCEPT_TOKEN(anon_sym_nth_DASHlast_DASHchild);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 167:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      ACCEPT_TOKEN(anon_sym_COLON_COLON);
       END_STATE();
     case 168:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '\n') ADVANCE(174);
-      if (lookahead == '\\') ADVANCE(168);
-      if (lookahead != 0) ADVANCE(176);
+      ACCEPT_TOKEN(anon_sym_POUND);
       END_STATE();
     case 169:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '*') ADVANCE(171);
-      if (lookahead == '/') ADVANCE(176);
-      if (lookahead == '\\') ADVANCE(175);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\'') ADVANCE(174);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 170:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '*') ADVANCE(170);
-      if (lookahead == '/') ADVANCE(174);
-      if (lookahead == '\\') ADVANCE(172);
-      if (lookahead == '\n' ||
-          lookahead == '\'') ADVANCE(25);
-      if (lookahead != 0) ADVANCE(171);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 171:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '*') ADVANCE(170);
-      if (lookahead == '\\') ADVANCE(172);
-      if (lookahead == '\n' ||
-          lookahead == '\'') ADVANCE(25);
-      if (lookahead != 0) ADVANCE(171);
+      ACCEPT_TOKEN(anon_sym_TILDE_EQ);
       END_STATE();
     case 172:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '*') ADVANCE(170);
-      if (lookahead == '\\') ADVANCE(172);
-      if (lookahead != 0) ADVANCE(171);
+      ACCEPT_TOKEN(anon_sym_CARET_EQ);
       END_STATE();
     case 173:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '/') ADVANCE(169);
-      if (lookahead == '\\') ADVANCE(175);
-      if (lookahead == '\t' ||
-          (0x0b <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(173);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != '\'') ADVANCE(174);
+      ACCEPT_TOKEN(anon_sym_PIPE_EQ);
       END_STATE();
     case 174:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '\\') ADVANCE(175);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\'') ADVANCE(174);
+      ACCEPT_TOKEN(anon_sym_STAR_EQ);
       END_STATE();
     case 175:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '\\') ADVANCE(175);
-      if (lookahead != 0) ADVANCE(174);
+      ACCEPT_TOKEN(anon_sym_DOLLAR_EQ);
       END_STATE();
     case 176:
-      ACCEPT_TOKEN(aux_sym_string_value_token1);
-      if (lookahead == '\\') ADVANCE(168);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\'') ADVANCE(176);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 177:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 178:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '\n') ADVANCE(184);
-      if (lookahead == '\\') ADVANCE(178);
-      if (lookahead != 0) ADVANCE(186);
+      ACCEPT_TOKEN(anon_sym_TILDE);
       END_STATE();
     case 179:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '*') ADVANCE(181);
-      if (lookahead == '/') ADVANCE(186);
-      if (lookahead == '\\') ADVANCE(185);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(184);
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      if (lookahead == '=') ADVANCE(171);
       END_STATE();
     case 180:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '*') ADVANCE(180);
-      if (lookahead == '/') ADVANCE(184);
-      if (lookahead == '\\') ADVANCE(182);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(25);
-      if (lookahead != 0) ADVANCE(181);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 181:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '*') ADVANCE(180);
-      if (lookahead == '\\') ADVANCE(182);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(25);
-      if (lookahead != 0) ADVANCE(181);
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(36);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       END_STATE();
     case 182:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '*') ADVANCE(180);
-      if (lookahead == '\\') ADVANCE(182);
-      if (lookahead != 0) ADVANCE(181);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 183:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '/') ADVANCE(179);
-      if (lookahead == '\\') ADVANCE(185);
-      if (lookahead == '\t' ||
-          (0x0b <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(183);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != '"') ADVANCE(184);
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '=') ADVANCE(173);
       END_STATE();
     case 184:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '\\') ADVANCE(185);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(184);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 185:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '\\') ADVANCE(185);
-      if (lookahead != 0) ADVANCE(184);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 186:
-      ACCEPT_TOKEN(aux_sym_string_value_token2);
-      if (lookahead == '\\') ADVANCE(178);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(186);
+      ACCEPT_TOKEN(anon_sym_even);
       END_STATE();
     case 187:
-      ACCEPT_TOKEN(aux_sym_integer_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(29);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      ACCEPT_TOKEN(anon_sym_odd);
       END_STATE();
     case 188:
-      ACCEPT_TOKEN(aux_sym_integer_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(63);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(189);
+      ACCEPT_TOKEN(anon_sym_of);
       END_STATE();
     case 189:
-      ACCEPT_TOKEN(aux_sym_integer_value_token1);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(137);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(165);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(143);
+      ACCEPT_TOKEN(anon_sym_of);
+      if (lookahead == '%' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(284);
       END_STATE();
     case 190:
-      ACCEPT_TOKEN(aux_sym_integer_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
+      ACCEPT_TOKEN(sym__nth_functional_notation);
+      if (lookahead == '+') ADVANCE(118);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(190);
       END_STATE();
     case 191:
-      ACCEPT_TOKEN(aux_sym_float_value_token1);
-      if (lookahead == '/') ADVANCE(66);
+      ACCEPT_TOKEN(sym__nth_functional_notation);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(191);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
       END_STATE();
     case 192:
-      ACCEPT_TOKEN(aux_sym_float_value_token1);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(29);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(192);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 193:
-      ACCEPT_TOKEN(aux_sym_float_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(193);
+      ACCEPT_TOKEN(anon_sym_COLON);
+      if (lookahead == ':') ADVANCE(167);
       END_STATE();
     case 194:
-      ACCEPT_TOKEN(aux_sym_float_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(194);
+      ACCEPT_TOKEN(sym_important);
+      END_STATE();
+    case 195:
+      ACCEPT_TOKEN(anon_sym_LPAREN2);
+      END_STATE();
+    case 196:
+      ACCEPT_TOKEN(anon_sym_and);
+      END_STATE();
+    case 197:
+      ACCEPT_TOKEN(anon_sym_and);
+      if (lookahead == '/') ADVANCE(126);
       if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
       END_STATE();
-    case 195:
-      ACCEPT_TOKEN(aux_sym_float_value_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(153);
+    case 198:
+      ACCEPT_TOKEN(anon_sym_or);
+      END_STATE();
+    case 199:
+      ACCEPT_TOKEN(anon_sym_or);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 200:
+      ACCEPT_TOKEN(anon_sym_only);
+      END_STATE();
+    case 201:
+      ACCEPT_TOKEN(anon_sym_only);
+      if (lookahead == '%') ADVANCE(284);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 202:
+      ACCEPT_TOKEN(anon_sym_only);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 203:
+      ACCEPT_TOKEN(anon_sym_only);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 204:
+      ACCEPT_TOKEN(anon_sym_selector);
+      END_STATE();
+    case 205:
+      ACCEPT_TOKEN(anon_sym_selector);
+      if (lookahead == '%') ADVANCE(284);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 206:
+      ACCEPT_TOKEN(anon_sym_selector);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 207:
+      ACCEPT_TOKEN(anon_sym_selector);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 208:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(265);
+      END_STATE();
+    case 210:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(221);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(164);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(208);
+      END_STATE();
+    case 211:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(222);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      END_STATE();
+    case 212:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(223);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(229);
+      END_STATE();
+    case 213:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(224);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(231);
+      END_STATE();
+    case 214:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '-') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(225);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(233);
+      END_STATE();
+    case 215:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(36);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
+      END_STATE();
+    case 216:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(209);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(208);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(215);
+      END_STATE();
+    case 217:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(211);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(229);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(218);
+      END_STATE();
+    case 218:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(210);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(216);
+      END_STATE();
+    case 219:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(212);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(231);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(217);
+      END_STATE();
+    case 220:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(213);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(233);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(219);
+      END_STATE();
+    case 221:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(265);
+      END_STATE();
+    case 222:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(221);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(208);
+      END_STATE();
+    case 223:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(222);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
+      END_STATE();
+    case 224:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(223);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(229);
+      END_STATE();
+    case 225:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(224);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(231);
+      END_STATE();
+    case 226:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(225);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(233);
+      END_STATE();
+    case 227:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(208);
+      END_STATE();
+    case 228:
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(237);
       if (lookahead == '-' ||
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 196:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'c') ADVANCE(206);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 197:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'e') ADVANCE(196);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 198:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'e') ADVANCE(200);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 199:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'l') ADVANCE(207);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 200:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'l') ADVANCE(197);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 201:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'n') ADVANCE(199);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 202:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'o') ADVANCE(205);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 203:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'o') ADVANCE(204);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 204:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'r') ADVANCE(128);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 205:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 't') ADVANCE(92);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 206:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 't') ADVANCE(203);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 207:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (lookahead == 'y') ADVANCE(125);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 208:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(212);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(208);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 209:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(211);
-      if (lookahead == '-') ADVANCE(238);
-      if (lookahead == '/') ADVANCE(66);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(191);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(210);
-      if (lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 210:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%') ADVANCE(211);
-      if (lookahead == '/') ADVANCE(66);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(210);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 211:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == '%' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(211);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 212:
-      ACCEPT_TOKEN(sym_unit);
-      if (lookahead == '%' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(212);
-      END_STATE();
-    case 213:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      END_STATE();
-    case 214:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == '/') ADVANCE(65);
-      if (lookahead == '-' ||
-          lookahead == '_') ADVANCE(222);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(221);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 215:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '.') ADVANCE(59);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(220);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 216:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 217:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead == '*') ADVANCE(25);
-      END_STATE();
-    case 218:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead == '*') ADVANCE(25);
-      if (lookahead == '/') ADVANCE(320);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(36);
-      END_STATE();
-    case 219:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '-') ADVANCE(268);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(195);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(269);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 220:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '-') ADVANCE(268);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(194);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 221:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '-') ADVANCE(238);
-      if (lookahead == '/') ADVANCE(66);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(191);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 222:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(65);
-      if (lookahead == '-' ||
-          lookahead == '_') ADVANCE(222);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(239);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 223:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'c') ADVANCE(236);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 224:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'd') ADVANCE(120);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 225:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'e') ADVANCE(223);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 226:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'e') ADVANCE(228);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 227:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'l') ADVANCE(237);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
-      END_STATE();
-    case 228:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'l') ADVANCE(225);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 229:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'n') ADVANCE(227);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(227);
       END_STATE();
     case 230:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'n') ADVANCE(224);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(228);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          ('g' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 231:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'o') ADVANCE(235);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(229);
       END_STATE();
     case 232:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'o') ADVANCE(233);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(230);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          ('g' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 233:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'r') ADVANCE(129);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(231);
       END_STATE();
     case 234:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'r') ADVANCE(123);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(232);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          ('g' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 235:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 't') ADVANCE(93);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(233);
       END_STATE();
     case 236:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 't') ADVANCE(232);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(234);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          ('g' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 237:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == 'y') ADVANCE(126);
+      ACCEPT_TOKEN(aux_sym_color_value_token1);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 238:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(191);
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      END_STATE();
+    case 239:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '\n') ADVANCE(245);
+      if (lookahead == '\\') ADVANCE(239);
+      if (lookahead != 0) ADVANCE(247);
+      END_STATE();
+    case 240:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '*') ADVANCE(242);
+      if (lookahead == '/') ADVANCE(247);
+      if (lookahead == '\\') ADVANCE(246);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\'') ADVANCE(245);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '*') ADVANCE(241);
+      if (lookahead == '/') ADVANCE(245);
+      if (lookahead == '\\') ADVANCE(243);
+      if (lookahead == '\n' ||
+          lookahead == '\'') ADVANCE(28);
+      if (lookahead != 0) ADVANCE(242);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '*') ADVANCE(241);
+      if (lookahead == '\\') ADVANCE(243);
+      if (lookahead == '\n' ||
+          lookahead == '\'') ADVANCE(28);
+      if (lookahead != 0) ADVANCE(242);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '*') ADVANCE(241);
+      if (lookahead == '\\') ADVANCE(243);
+      if (lookahead != 0) ADVANCE(242);
+      END_STATE();
+    case 244:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '/') ADVANCE(240);
+      if (lookahead == '\\') ADVANCE(246);
+      if (lookahead == '\t' ||
+          (0x0b <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(244);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != '\'') ADVANCE(245);
+      END_STATE();
+    case 245:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '\\') ADVANCE(246);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\'') ADVANCE(245);
+      END_STATE();
+    case 246:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '\\') ADVANCE(246);
+      if (lookahead != 0) ADVANCE(245);
+      END_STATE();
+    case 247:
+      ACCEPT_TOKEN(aux_sym_string_value_token1);
+      if (lookahead == '\\') ADVANCE(239);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\'') ADVANCE(247);
+      END_STATE();
+    case 248:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 249:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '\n') ADVANCE(255);
+      if (lookahead == '\\') ADVANCE(249);
+      if (lookahead != 0) ADVANCE(257);
+      END_STATE();
+    case 250:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '*') ADVANCE(252);
+      if (lookahead == '/') ADVANCE(257);
+      if (lookahead == '\\') ADVANCE(256);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(255);
+      END_STATE();
+    case 251:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '*') ADVANCE(251);
+      if (lookahead == '/') ADVANCE(255);
+      if (lookahead == '\\') ADVANCE(253);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(28);
+      if (lookahead != 0) ADVANCE(252);
+      END_STATE();
+    case 252:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '*') ADVANCE(251);
+      if (lookahead == '\\') ADVANCE(253);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(28);
+      if (lookahead != 0) ADVANCE(252);
+      END_STATE();
+    case 253:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '*') ADVANCE(251);
+      if (lookahead == '\\') ADVANCE(253);
+      if (lookahead != 0) ADVANCE(252);
+      END_STATE();
+    case 254:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '/') ADVANCE(250);
+      if (lookahead == '\\') ADVANCE(256);
+      if (lookahead == '\t' ||
+          (0x0b <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(254);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != '"') ADVANCE(255);
+      END_STATE();
+    case 255:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '\\') ADVANCE(256);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(255);
+      END_STATE();
+    case 256:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '\\') ADVANCE(256);
+      if (lookahead != 0) ADVANCE(255);
+      END_STATE();
+    case 257:
+      ACCEPT_TOKEN(aux_sym_string_value_token2);
+      if (lookahead == '\\') ADVANCE(249);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(257);
+      END_STATE();
+    case 258:
+      ACCEPT_TOKEN(aux_sym_integer_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(36);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
+      END_STATE();
+    case 259:
+      ACCEPT_TOKEN(aux_sym_integer_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(214);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(235);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(220);
+      END_STATE();
+    case 260:
+      ACCEPT_TOKEN(aux_sym_integer_value_token1);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(37);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(122);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(259);
+      END_STATE();
+    case 261:
+      ACCEPT_TOKEN(aux_sym_integer_value_token1);
+      if (lookahead == 'n') ADVANCE(190);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(261);
+      END_STATE();
+    case 262:
+      ACCEPT_TOKEN(aux_sym_integer_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(262);
+      END_STATE();
+    case 263:
+      ACCEPT_TOKEN(aux_sym_float_value_token1);
+      if (lookahead == '/') ADVANCE(126);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(263);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
       END_STATE();
-    case 239:
+    case 264:
+      ACCEPT_TOKEN(aux_sym_float_value_token1);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(36);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(264);
+      END_STATE();
+    case 265:
+      ACCEPT_TOKEN(aux_sym_float_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(265);
+      END_STATE();
+    case 266:
+      ACCEPT_TOKEN(aux_sym_float_value_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(226);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(235);
+      END_STATE();
+    case 267:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'c') ADVANCE(277);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 268:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'e') ADVANCE(267);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 269:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'e') ADVANCE(271);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 270:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'l') ADVANCE(278);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 271:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'l') ADVANCE(268);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 272:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'n') ADVANCE(270);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 273:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'o') ADVANCE(276);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 274:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'o') ADVANCE(275);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 275:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'r') ADVANCE(205);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 276:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 't') ADVANCE(152);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 277:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 't') ADVANCE(274);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 278:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (lookahead == 'y') ADVANCE(201);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 279:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(284);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(279);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 280:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(282);
+      if (lookahead == '-') ADVANCE(310);
+      if (lookahead == '/') ADVANCE(126);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(263);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(281);
+      if (lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 281:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%') ADVANCE(282);
+      if (lookahead == '/') ADVANCE(126);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(281);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 282:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == '%' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(282);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 283:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == 'f') ADVANCE(189);
+      if (lookahead == '%' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(284);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(sym_unit);
+      if (lookahead == '%' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(284);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      END_STATE();
+    case 286:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(125);
+      if (lookahead == '-' ||
+          lookahead == '_') ADVANCE(294);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(291);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if ((0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(36);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      if (lookahead == '*') ADVANCE(28);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      if (lookahead == '*') ADVANCE(28);
+      if (lookahead == '/') ADVANCE(406);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(45);
+      END_STATE();
+    case 291:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(66);
+      if (lookahead == '-') ADVANCE(310);
+      if (lookahead == '/') ADVANCE(126);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(263);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 292:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '-') ADVANCE(315);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 293:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '-') ADVANCE(317);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 294:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(125);
+      if (lookahead == '-' ||
+          lookahead == '_') ADVANCE(294);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(311);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 295:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'c') ADVANCE(308);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(239);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
       END_STATE();
-    case 240:
+    case 296:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(264);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'd') ADVANCE(197);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 297:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'e') ADVANCE(295);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'e') ADVANCE(300);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 299:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'l') ADVANCE(309);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 300:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'l') ADVANCE(297);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 301:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'n') ADVANCE(299);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 302:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'n') ADVANCE(296);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 303:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'o') ADVANCE(307);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 304:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'o') ADVANCE(305);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 305:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'r') ADVANCE(206);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 306:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'r') ADVANCE(199);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 307:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 't') ADVANCE(153);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 308:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 't') ADVANCE(304);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 309:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == 'y') ADVANCE(202);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 310:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(263);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 311:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '/') ADVANCE(126);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(311);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
+      END_STATE();
+    case 312:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(344);
+      if (lookahead == 'o') ADVANCE(345);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('b' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 241:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(266);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 242:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(121);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 243:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(241);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 244:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(96);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 245:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(249);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 246:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(262);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 247:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'h') ADVANCE(246);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 248:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(267);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 249:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(243);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 250:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(82);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 251:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(242);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(269);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 252:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(242);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 253:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(248);
-      if (lookahead == 'r') ADVANCE(124);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 254:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(248);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 255:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(265);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 256:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(84);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 257:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(250);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 258:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(259);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 259:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(130);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 260:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(257);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(269);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 261:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(257);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 262:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(244);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 263:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(95);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 264:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(91);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 265:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(94);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 266:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(258);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 267:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(127);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 268:
-      ACCEPT_TOKEN(sym_identifier);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(194);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 269:
-      ACCEPT_TOKEN(sym_identifier);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(164);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 270:
-      ACCEPT_TOKEN(sym_identifier);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(269);
-      if (lookahead == '-' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 271:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(271);
-      END_STATE();
-    case 272:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'a') ADVANCE(302);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 273:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'a') ADVANCE(74);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 274:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'a') ADVANCE(278);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 275:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'a') ADVANCE(293);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 276:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'a') ADVANCE(294);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 277:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'a') ADVANCE(295);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 278:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'c') ADVANCE(282);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 279:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'd') ADVANCE(291);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 280:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'e') ADVANCE(316);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 281:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'e') ADVANCE(279);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 282:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'e') ADVANCE(76);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 283:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'e') ADVANCE(310);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 284:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'e') ADVANCE(313);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 285:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'e') ADVANCE(308);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 286:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'e') ADVANCE(309);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 287:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'e') ADVANCE(317);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 288:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'f') ADVANCE(305);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 289:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'f') ADVANCE(306);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 290:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'h') ADVANCE(272);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 291:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'i') ADVANCE(273);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 292:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'm') ADVANCE(298);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 293:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'm') ADVANCE(283);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 294:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'm') ADVANCE(285);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 295:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'm') ADVANCE(286);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 296:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'o') ADVANCE(303);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 297:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'o') ADVANCE(304);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 298:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'p') ADVANCE(296);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 299:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'p') ADVANCE(274);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 300:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'p') ADVANCE(297);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 301:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'p') ADVANCE(300);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 302:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'r') ADVANCE(311);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 303:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'r') ADVANCE(312);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 304:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'r') ADVANCE(314);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 305:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'r') ADVANCE(276);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 306:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'r') ADVANCE(277);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 307:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 's') ADVANCE(85);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 308:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 's') ADVANCE(77);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 309:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 's') ADVANCE(78);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 310:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 's') ADVANCE(299);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 311:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 's') ADVANCE(284);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
-      END_STATE();
-    case 312:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 't') ADVANCE(71);
-      if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 313:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 't') ADVANCE(75);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(346);
       if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 314:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 't') ADVANCE(307);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(339);
       if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 315:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'u') ADVANCE(301);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(327);
+      if (lookahead == 'l') ADVANCE(313);
       if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 316:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'y') ADVANCE(288);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(352);
       if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 317:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
-      if (lookahead == 'y') ADVANCE(289);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(328);
       if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 318:
-      ACCEPT_TOKEN(sym_at_keyword);
-      if (lookahead == 'k') ADVANCE(287);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(164);
       if (lookahead == '-' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(318);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(319);
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
       END_STATE();
     case 319:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(166);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 320:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(342);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 321:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(158);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 322:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(353);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 323:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(316);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 324:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(334);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 325:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(320);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 326:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(292);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 327:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(329);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 328:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(330);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 329:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(331);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 330:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(333);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 331:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(318);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 332:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(354);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 333:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(319);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 334:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(323);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 335:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(332);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 336:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(351);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 337:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(347);
+      if (lookahead == 't') ADVANCE(326);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 338:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(347);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 339:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(336);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 340:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(341);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 341:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(207);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 342:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(321);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 343:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(156);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 344:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(150);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 345:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(348);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 346:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(350);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 347:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(154);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 348:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(159);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 349:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(162);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 350:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(293);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 351:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(322);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 352:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(340);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 353:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'x') ADVANCE(349);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 354:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(203);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 355:
+      ACCEPT_TOKEN(sym_identifier);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(236);
+      if (lookahead == '-' ||
+          ('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('g' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 356:
+      ACCEPT_TOKEN(sym_identifier);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(355);
+      if (lookahead == '-' ||
+          ('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('g' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 357:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (0xa0 <= lookahead && lookahead <= 0xff)) ADVANCE(357);
+      END_STATE();
+    case 358:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'a') ADVANCE(388);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 359:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'a') ADVANCE(134);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 360:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'a') ADVANCE(364);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'a') ADVANCE(379);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'a') ADVANCE(380);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'a') ADVANCE(381);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'c') ADVANCE(368);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 365:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'd') ADVANCE(377);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'e') ADVANCE(402);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 367:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'e') ADVANCE(365);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 368:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'e') ADVANCE(136);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 369:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'e') ADVANCE(396);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 370:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'e') ADVANCE(399);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 371:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'e') ADVANCE(394);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 372:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'e') ADVANCE(395);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 373:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'e') ADVANCE(403);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 374:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'f') ADVANCE(391);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 375:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'f') ADVANCE(392);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 376:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'h') ADVANCE(358);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 377:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'i') ADVANCE(359);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 378:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'm') ADVANCE(384);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 379:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'm') ADVANCE(369);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 380:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'm') ADVANCE(371);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 381:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'm') ADVANCE(372);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 382:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'o') ADVANCE(389);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 383:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'o') ADVANCE(390);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 384:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'p') ADVANCE(382);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 385:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'p') ADVANCE(360);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 386:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'p') ADVANCE(383);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 387:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'p') ADVANCE(386);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 388:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'r') ADVANCE(397);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 389:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'r') ADVANCE(398);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 390:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'r') ADVANCE(400);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 391:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'r') ADVANCE(362);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 392:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'r') ADVANCE(363);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 393:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 's') ADVANCE(143);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 394:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 's') ADVANCE(137);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 395:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 's') ADVANCE(138);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 396:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 's') ADVANCE(385);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 397:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 's') ADVANCE(370);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 398:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 't') ADVANCE(131);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 399:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 't') ADVANCE(135);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 400:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 't') ADVANCE(393);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 401:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'u') ADVANCE(387);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 402:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'y') ADVANCE(374);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 403:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == 'y') ADVANCE(375);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 404:
+      ACCEPT_TOKEN(sym_at_keyword);
+      if (lookahead == 'k') ADVANCE(373);
+      if (lookahead == '-' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(404);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(405);
+      END_STATE();
+    case 405:
       ACCEPT_TOKEN(sym_at_keyword);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(319);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(405);
       END_STATE();
-    case 320:
+    case 406:
       ACCEPT_TOKEN(sym_js_comment);
-      if (lookahead == '/') ADVANCE(321);
+      if (lookahead == '/') ADVANCE(407);
       if (lookahead == '-' ||
-          lookahead == '_') ADVANCE(320);
+          lookahead == '_') ADVANCE(406);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(326);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(412);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(323);
+          lookahead != '\n') ADVANCE(409);
       END_STATE();
-    case 321:
+    case 407:
       ACCEPT_TOKEN(sym_js_comment);
       if (lookahead == '\t' ||
           (0x0b <= lookahead && lookahead <= '\r') ||
@@ -4354,11 +4787,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '[' ||
           lookahead == ']' ||
           lookahead == '{' ||
-          lookahead == '}') ADVANCE(323);
+          lookahead == '}') ADVANCE(409);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(320);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(406);
       END_STATE();
-    case 322:
+    case 408:
       ACCEPT_TOKEN(sym_js_comment);
       if (lookahead == '\t' ||
           (0x0b <= lookahead && lookahead <= '\r') ||
@@ -4370,27 +4803,27 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '[' ||
           lookahead == ']' ||
           lookahead == '{' ||
-          lookahead == '}') ADVANCE(323);
+          lookahead == '}') ADVANCE(409);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(326);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(412);
       END_STATE();
-    case 323:
+    case 409:
       ACCEPT_TOKEN(sym_js_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(323);
+          lookahead != '\n') ADVANCE(409);
       END_STATE();
-    case 324:
+    case 410:
       ACCEPT_TOKEN(sym_comment);
       END_STATE();
-    case 325:
+    case 411:
       ACCEPT_TOKEN(sym_plain_value);
-      if (lookahead == '/') ADVANCE(66);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(325);
+      if (lookahead == '/') ADVANCE(126);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(411);
       END_STATE();
-    case 326:
+    case 412:
       ACCEPT_TOKEN(sym_plain_value);
-      if (lookahead == '/') ADVANCE(322);
-      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(326);
+      if (lookahead == '/') ADVANCE(408);
+      if ((!eof && set_contains(sym_plain_value_character_set_2, 10, lookahead))) ADVANCE(412);
       END_STATE();
     default:
       return false;
@@ -4399,16 +4832,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
-  [1] = {.lex_state = 68, .external_lex_state = 2},
-  [2] = {.lex_state = 68, .external_lex_state = 2},
-  [3] = {.lex_state = 68, .external_lex_state = 2},
-  [4] = {.lex_state = 68, .external_lex_state = 2},
-  [5] = {.lex_state = 68, .external_lex_state = 2},
-  [6] = {.lex_state = 68, .external_lex_state = 2},
-  [7] = {.lex_state = 68, .external_lex_state = 2},
-  [8] = {.lex_state = 68, .external_lex_state = 2},
-  [9] = {.lex_state = 68, .external_lex_state = 2},
-  [10] = {.lex_state = 68, .external_lex_state = 2},
+  [1] = {.lex_state = 128, .external_lex_state = 2},
+  [2] = {.lex_state = 128, .external_lex_state = 2},
+  [3] = {.lex_state = 128, .external_lex_state = 2},
+  [4] = {.lex_state = 128, .external_lex_state = 2},
+  [5] = {.lex_state = 128, .external_lex_state = 2},
+  [6] = {.lex_state = 128, .external_lex_state = 2},
+  [7] = {.lex_state = 128, .external_lex_state = 2},
+  [8] = {.lex_state = 128, .external_lex_state = 2},
+  [9] = {.lex_state = 128, .external_lex_state = 2},
+  [10] = {.lex_state = 128, .external_lex_state = 2},
   [11] = {.lex_state = 2, .external_lex_state = 2},
   [12] = {.lex_state = 2, .external_lex_state = 2},
   [13] = {.lex_state = 2, .external_lex_state = 2},
@@ -4423,145 +4856,145 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [22] = {.lex_state = 3, .external_lex_state = 3},
   [23] = {.lex_state = 2},
   [24] = {.lex_state = 2},
-  [25] = {.lex_state = 68, .external_lex_state = 2},
+  [25] = {.lex_state = 128, .external_lex_state = 2},
   [26] = {.lex_state = 2},
-  [27] = {.lex_state = 2},
-  [28] = {.lex_state = 68, .external_lex_state = 2},
-  [29] = {.lex_state = 68, .external_lex_state = 2},
-  [30] = {.lex_state = 68, .external_lex_state = 2},
-  [31] = {.lex_state = 68, .external_lex_state = 2},
-  [32] = {.lex_state = 10, .external_lex_state = 3},
-  [33] = {.lex_state = 68, .external_lex_state = 2},
-  [34] = {.lex_state = 2},
-  [35] = {.lex_state = 68, .external_lex_state = 2},
+  [27] = {.lex_state = 128, .external_lex_state = 2},
+  [28] = {.lex_state = 2},
+  [29] = {.lex_state = 2},
+  [30] = {.lex_state = 128, .external_lex_state = 2},
+  [31] = {.lex_state = 128, .external_lex_state = 2},
+  [32] = {.lex_state = 128, .external_lex_state = 2},
+  [33] = {.lex_state = 128, .external_lex_state = 2},
+  [34] = {.lex_state = 10, .external_lex_state = 3},
+  [35] = {.lex_state = 2},
   [36] = {.lex_state = 2},
   [37] = {.lex_state = 2},
-  [38] = {.lex_state = 5, .external_lex_state = 3},
-  [39] = {.lex_state = 2},
+  [38] = {.lex_state = 2},
+  [39] = {.lex_state = 5, .external_lex_state = 3},
   [40] = {.lex_state = 5, .external_lex_state = 3},
-  [41] = {.lex_state = 68, .external_lex_state = 2},
-  [42] = {.lex_state = 68, .external_lex_state = 2},
-  [43] = {.lex_state = 2},
-  [44] = {.lex_state = 68, .external_lex_state = 2},
-  [45] = {.lex_state = 9, .external_lex_state = 3},
-  [46] = {.lex_state = 2},
+  [41] = {.lex_state = 128, .external_lex_state = 2},
+  [42] = {.lex_state = 128, .external_lex_state = 2},
+  [43] = {.lex_state = 128, .external_lex_state = 2},
+  [44] = {.lex_state = 128, .external_lex_state = 2},
+  [45] = {.lex_state = 128, .external_lex_state = 2},
+  [46] = {.lex_state = 9, .external_lex_state = 3},
   [47] = {.lex_state = 2},
   [48] = {.lex_state = 9, .external_lex_state = 3},
-  [49] = {.lex_state = 2},
-  [50] = {.lex_state = 9, .external_lex_state = 3},
-  [51] = {.lex_state = 9, .external_lex_state = 3},
-  [52] = {.lex_state = 2},
+  [49] = {.lex_state = 9, .external_lex_state = 3},
+  [50] = {.lex_state = 2},
+  [51] = {.lex_state = 2},
+  [52] = {.lex_state = 9, .external_lex_state = 3},
   [53] = {.lex_state = 4},
   [54] = {.lex_state = 2},
   [55] = {.lex_state = 2},
   [56] = {.lex_state = 2},
   [57] = {.lex_state = 2},
-  [58] = {.lex_state = 9, .external_lex_state = 3},
+  [58] = {.lex_state = 2},
   [59] = {.lex_state = 9, .external_lex_state = 3},
   [60] = {.lex_state = 9, .external_lex_state = 3},
   [61] = {.lex_state = 9, .external_lex_state = 3},
-  [62] = {.lex_state = 2},
+  [62] = {.lex_state = 9, .external_lex_state = 3},
   [63] = {.lex_state = 9, .external_lex_state = 3},
   [64] = {.lex_state = 9, .external_lex_state = 3},
-  [65] = {.lex_state = 9, .external_lex_state = 3},
+  [65] = {.lex_state = 2},
   [66] = {.lex_state = 9, .external_lex_state = 3},
   [67] = {.lex_state = 9, .external_lex_state = 3},
   [68] = {.lex_state = 9, .external_lex_state = 3},
-  [69] = {.lex_state = 2},
+  [69] = {.lex_state = 9, .external_lex_state = 3},
   [70] = {.lex_state = 9, .external_lex_state = 3},
   [71] = {.lex_state = 9, .external_lex_state = 3},
   [72] = {.lex_state = 9, .external_lex_state = 3},
-  [73] = {.lex_state = 9, .external_lex_state = 3},
+  [73] = {.lex_state = 2},
   [74] = {.lex_state = 9, .external_lex_state = 3},
   [75] = {.lex_state = 9, .external_lex_state = 3},
   [76] = {.lex_state = 9, .external_lex_state = 3},
   [77] = {.lex_state = 9, .external_lex_state = 3},
   [78] = {.lex_state = 9, .external_lex_state = 3},
   [79] = {.lex_state = 9, .external_lex_state = 3},
-  [80] = {.lex_state = 3},
+  [80] = {.lex_state = 9, .external_lex_state = 3},
   [81] = {.lex_state = 9, .external_lex_state = 3},
   [82] = {.lex_state = 9, .external_lex_state = 3},
   [83] = {.lex_state = 9, .external_lex_state = 3},
-  [84] = {.lex_state = 9, .external_lex_state = 3},
+  [84] = {.lex_state = 3},
   [85] = {.lex_state = 9, .external_lex_state = 3},
   [86] = {.lex_state = 9, .external_lex_state = 3},
   [87] = {.lex_state = 9, .external_lex_state = 3},
   [88] = {.lex_state = 9, .external_lex_state = 3},
   [89] = {.lex_state = 9, .external_lex_state = 3},
-  [90] = {.lex_state = 68, .external_lex_state = 2},
-  [91] = {.lex_state = 68, .external_lex_state = 2},
-  [92] = {.lex_state = 68, .external_lex_state = 2},
-  [93] = {.lex_state = 68, .external_lex_state = 2},
-  [94] = {.lex_state = 68, .external_lex_state = 2},
-  [95] = {.lex_state = 2},
-  [96] = {.lex_state = 68, .external_lex_state = 2},
-  [97] = {.lex_state = 68, .external_lex_state = 2},
-  [98] = {.lex_state = 68, .external_lex_state = 2},
-  [99] = {.lex_state = 68, .external_lex_state = 2},
-  [100] = {.lex_state = 68, .external_lex_state = 2},
+  [90] = {.lex_state = 9, .external_lex_state = 3},
+  [91] = {.lex_state = 9, .external_lex_state = 3},
+  [92] = {.lex_state = 9, .external_lex_state = 3},
+  [93] = {.lex_state = 9, .external_lex_state = 3},
+  [94] = {.lex_state = 9, .external_lex_state = 3},
+  [95] = {.lex_state = 9, .external_lex_state = 3},
+  [96] = {.lex_state = 128, .external_lex_state = 2},
+  [97] = {.lex_state = 128, .external_lex_state = 2},
+  [98] = {.lex_state = 2},
+  [99] = {.lex_state = 128, .external_lex_state = 2},
+  [100] = {.lex_state = 128, .external_lex_state = 2},
   [101] = {.lex_state = 2},
-  [102] = {.lex_state = 68, .external_lex_state = 2},
-  [103] = {.lex_state = 68, .external_lex_state = 2},
-  [104] = {.lex_state = 68, .external_lex_state = 2},
-  [105] = {.lex_state = 68, .external_lex_state = 2},
-  [106] = {.lex_state = 68, .external_lex_state = 2},
-  [107] = {.lex_state = 2},
-  [108] = {.lex_state = 68, .external_lex_state = 2},
-  [109] = {.lex_state = 68, .external_lex_state = 2},
-  [110] = {.lex_state = 68, .external_lex_state = 2},
-  [111] = {.lex_state = 2},
-  [112] = {.lex_state = 2},
-  [113] = {.lex_state = 68, .external_lex_state = 2},
-  [114] = {.lex_state = 68, .external_lex_state = 2},
-  [115] = {.lex_state = 68, .external_lex_state = 2},
+  [102] = {.lex_state = 128, .external_lex_state = 2},
+  [103] = {.lex_state = 2},
+  [104] = {.lex_state = 2},
+  [105] = {.lex_state = 128, .external_lex_state = 2},
+  [106] = {.lex_state = 128, .external_lex_state = 2},
+  [107] = {.lex_state = 128, .external_lex_state = 2},
+  [108] = {.lex_state = 128, .external_lex_state = 2},
+  [109] = {.lex_state = 2},
+  [110] = {.lex_state = 2},
+  [111] = {.lex_state = 128, .external_lex_state = 2},
+  [112] = {.lex_state = 128, .external_lex_state = 2},
+  [113] = {.lex_state = 128, .external_lex_state = 2},
+  [114] = {.lex_state = 128, .external_lex_state = 2},
+  [115] = {.lex_state = 128, .external_lex_state = 2},
   [116] = {.lex_state = 2},
-  [117] = {.lex_state = 2},
-  [118] = {.lex_state = 68, .external_lex_state = 2},
-  [119] = {.lex_state = 68, .external_lex_state = 2},
-  [120] = {.lex_state = 68, .external_lex_state = 2},
-  [121] = {.lex_state = 68, .external_lex_state = 2},
-  [122] = {.lex_state = 68, .external_lex_state = 2},
-  [123] = {.lex_state = 68, .external_lex_state = 2},
-  [124] = {.lex_state = 68, .external_lex_state = 2},
-  [125] = {.lex_state = 68, .external_lex_state = 2},
-  [126] = {.lex_state = 68, .external_lex_state = 2},
-  [127] = {.lex_state = 68, .external_lex_state = 2},
-  [128] = {.lex_state = 68, .external_lex_state = 2},
-  [129] = {.lex_state = 68, .external_lex_state = 2},
-  [130] = {.lex_state = 68, .external_lex_state = 2},
-  [131] = {.lex_state = 68, .external_lex_state = 2},
-  [132] = {.lex_state = 68, .external_lex_state = 2},
-  [133] = {.lex_state = 2},
-  [134] = {.lex_state = 68, .external_lex_state = 2},
-  [135] = {.lex_state = 68, .external_lex_state = 2},
-  [136] = {.lex_state = 1},
-  [137] = {.lex_state = 1},
-  [138] = {.lex_state = 68, .external_lex_state = 2},
+  [117] = {.lex_state = 128, .external_lex_state = 2},
+  [118] = {.lex_state = 128, .external_lex_state = 2},
+  [119] = {.lex_state = 128, .external_lex_state = 2},
+  [120] = {.lex_state = 2},
+  [121] = {.lex_state = 128, .external_lex_state = 2},
+  [122] = {.lex_state = 128, .external_lex_state = 2},
+  [123] = {.lex_state = 128, .external_lex_state = 2},
+  [124] = {.lex_state = 128, .external_lex_state = 2},
+  [125] = {.lex_state = 128, .external_lex_state = 2},
+  [126] = {.lex_state = 128, .external_lex_state = 2},
+  [127] = {.lex_state = 128, .external_lex_state = 2},
+  [128] = {.lex_state = 128, .external_lex_state = 2},
+  [129] = {.lex_state = 128, .external_lex_state = 2},
+  [130] = {.lex_state = 128, .external_lex_state = 2},
+  [131] = {.lex_state = 128, .external_lex_state = 2},
+  [132] = {.lex_state = 128, .external_lex_state = 2},
+  [133] = {.lex_state = 128, .external_lex_state = 2},
+  [134] = {.lex_state = 128, .external_lex_state = 2},
+  [135] = {.lex_state = 128, .external_lex_state = 2},
+  [136] = {.lex_state = 128, .external_lex_state = 2},
+  [137] = {.lex_state = 128, .external_lex_state = 2},
+  [138] = {.lex_state = 128, .external_lex_state = 2},
   [139] = {.lex_state = 2},
-  [140] = {.lex_state = 2},
-  [141] = {.lex_state = 68, .external_lex_state = 2},
-  [142] = {.lex_state = 68, .external_lex_state = 2},
-  [143] = {.lex_state = 68, .external_lex_state = 2},
-  [144] = {.lex_state = 68, .external_lex_state = 2},
-  [145] = {.lex_state = 68, .external_lex_state = 2},
-  [146] = {.lex_state = 68, .external_lex_state = 2},
+  [140] = {.lex_state = 1},
+  [141] = {.lex_state = 1},
+  [142] = {.lex_state = 128, .external_lex_state = 2},
+  [143] = {.lex_state = 2},
+  [144] = {.lex_state = 2},
+  [145] = {.lex_state = 128, .external_lex_state = 2},
+  [146] = {.lex_state = 128, .external_lex_state = 2},
   [147] = {.lex_state = 2},
   [148] = {.lex_state = 2},
-  [149] = {.lex_state = 2},
-  [150] = {.lex_state = 2},
-  [151] = {.lex_state = 2},
-  [152] = {.lex_state = 2},
-  [153] = {.lex_state = 2},
+  [149] = {.lex_state = 128, .external_lex_state = 2},
+  [150] = {.lex_state = 128, .external_lex_state = 2},
+  [151] = {.lex_state = 128, .external_lex_state = 2},
+  [152] = {.lex_state = 128, .external_lex_state = 2},
+  [153] = {.lex_state = 128, .external_lex_state = 2},
   [154] = {.lex_state = 2},
   [155] = {.lex_state = 2},
   [156] = {.lex_state = 2},
-  [157] = {.lex_state = 68, .external_lex_state = 2},
-  [158] = {.lex_state = 5},
-  [159] = {.lex_state = 5},
-  [160] = {.lex_state = 5},
-  [161] = {.lex_state = 5},
-  [162] = {.lex_state = 5},
-  [163] = {.lex_state = 5},
+  [157] = {.lex_state = 2},
+  [158] = {.lex_state = 2},
+  [159] = {.lex_state = 128, .external_lex_state = 2},
+  [160] = {.lex_state = 128, .external_lex_state = 2},
+  [161] = {.lex_state = 2},
+  [162] = {.lex_state = 2},
+  [163] = {.lex_state = 128, .external_lex_state = 2},
   [164] = {.lex_state = 5},
   [165] = {.lex_state = 5},
   [166] = {.lex_state = 5},
@@ -4570,194 +5003,205 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [169] = {.lex_state = 5},
   [170] = {.lex_state = 5},
   [171] = {.lex_state = 5},
-  [172] = {.lex_state = 9, .external_lex_state = 3},
+  [172] = {.lex_state = 5},
   [173] = {.lex_state = 5},
-  [174] = {.lex_state = 9, .external_lex_state = 3},
+  [174] = {.lex_state = 5},
   [175] = {.lex_state = 5},
-  [176] = {.lex_state = 9, .external_lex_state = 3},
-  [177] = {.lex_state = 9, .external_lex_state = 3},
-  [178] = {.lex_state = 5},
+  [176] = {.lex_state = 5},
+  [177] = {.lex_state = 5},
+  [178] = {.lex_state = 9, .external_lex_state = 3},
   [179] = {.lex_state = 5},
   [180] = {.lex_state = 5},
-  [181] = {.lex_state = 5},
-  [182] = {.lex_state = 17},
-  [183] = {.lex_state = 17},
+  [181] = {.lex_state = 9, .external_lex_state = 3},
+  [182] = {.lex_state = 9, .external_lex_state = 3},
+  [183] = {.lex_state = 9, .external_lex_state = 3},
   [184] = {.lex_state = 5},
-  [185] = {.lex_state = 13, .external_lex_state = 3},
-  [186] = {.lex_state = 13, .external_lex_state = 3},
-  [187] = {.lex_state = 19},
-  [188] = {.lex_state = 68, .external_lex_state = 3},
-  [189] = {.lex_state = 68, .external_lex_state = 3},
-  [190] = {.lex_state = 68, .external_lex_state = 3},
-  [191] = {.lex_state = 68, .external_lex_state = 3},
-  [192] = {.lex_state = 68, .external_lex_state = 3},
-  [193] = {.lex_state = 68, .external_lex_state = 3},
-  [194] = {.lex_state = 68, .external_lex_state = 3},
-  [195] = {.lex_state = 68, .external_lex_state = 3},
-  [196] = {.lex_state = 68, .external_lex_state = 3},
-  [197] = {.lex_state = 16},
-  [198] = {.lex_state = 15},
-  [199] = {.lex_state = 19},
-  [200] = {.lex_state = 19},
-  [201] = {.lex_state = 19},
-  [202] = {.lex_state = 15},
-  [203] = {.lex_state = 68, .external_lex_state = 3},
-  [204] = {.lex_state = 19},
-  [205] = {.lex_state = 17},
+  [185] = {.lex_state = 5},
+  [186] = {.lex_state = 5},
+  [187] = {.lex_state = 5},
+  [188] = {.lex_state = 17},
+  [189] = {.lex_state = 5},
+  [190] = {.lex_state = 17},
+  [191] = {.lex_state = 13, .external_lex_state = 3},
+  [192] = {.lex_state = 13, .external_lex_state = 3},
+  [193] = {.lex_state = 19},
+  [194] = {.lex_state = 128, .external_lex_state = 3},
+  [195] = {.lex_state = 128, .external_lex_state = 3},
+  [196] = {.lex_state = 128, .external_lex_state = 3},
+  [197] = {.lex_state = 128, .external_lex_state = 3},
+  [198] = {.lex_state = 128, .external_lex_state = 3},
+  [199] = {.lex_state = 128, .external_lex_state = 3},
+  [200] = {.lex_state = 128, .external_lex_state = 3},
+  [201] = {.lex_state = 128, .external_lex_state = 3},
+  [202] = {.lex_state = 128, .external_lex_state = 3},
+  [203] = {.lex_state = 16},
+  [204] = {.lex_state = 128, .external_lex_state = 3},
+  [205] = {.lex_state = 19},
   [206] = {.lex_state = 19},
-  [207] = {.lex_state = 19},
-  [208] = {.lex_state = 19},
-  [209] = {.lex_state = 19},
-  [210] = {.lex_state = 68, .external_lex_state = 3},
-  [211] = {.lex_state = 13},
-  [212] = {.lex_state = 17},
-  [213] = {.lex_state = 17},
-  [214] = {.lex_state = 17},
-  [215] = {.lex_state = 17},
-  [216] = {.lex_state = 17},
+  [207] = {.lex_state = 15},
+  [208] = {.lex_state = 15},
+  [209] = {.lex_state = 128, .external_lex_state = 3},
+  [210] = {.lex_state = 17},
+  [211] = {.lex_state = 19},
+  [212] = {.lex_state = 19},
+  [213] = {.lex_state = 19},
+  [214] = {.lex_state = 19},
+  [215] = {.lex_state = 19},
+  [216] = {.lex_state = 19},
   [217] = {.lex_state = 17},
   [218] = {.lex_state = 17},
   [219] = {.lex_state = 17},
-  [220] = {.lex_state = 17},
+  [220] = {.lex_state = 9},
   [221] = {.lex_state = 17},
-  [222] = {.lex_state = 13},
+  [222] = {.lex_state = 17},
   [223] = {.lex_state = 17},
-  [224] = {.lex_state = 21},
-  [225] = {.lex_state = 21},
+  [224] = {.lex_state = 128, .external_lex_state = 3},
+  [225] = {.lex_state = 9},
   [226] = {.lex_state = 13},
   [227] = {.lex_state = 13},
-  [228] = {.lex_state = 13},
-  [229] = {.lex_state = 13},
-  [230] = {.lex_state = 13},
-  [231] = {.lex_state = 13},
-  [232] = {.lex_state = 13},
-  [233] = {.lex_state = 13},
-  [234] = {.lex_state = 13},
+  [228] = {.lex_state = 17},
+  [229] = {.lex_state = 17},
+  [230] = {.lex_state = 17},
+  [231] = {.lex_state = 17},
+  [232] = {.lex_state = 17},
+  [233] = {.lex_state = 21},
+  [234] = {.lex_state = 21},
   [235] = {.lex_state = 13},
   [236] = {.lex_state = 13},
   [237] = {.lex_state = 13},
-  [238] = {.lex_state = 33},
+  [238] = {.lex_state = 13},
   [239] = {.lex_state = 13},
-  [240] = {.lex_state = 33},
-  [241] = {.lex_state = 68},
-  [242] = {.lex_state = 33},
-  [243] = {.lex_state = 33},
+  [240] = {.lex_state = 13},
+  [241] = {.lex_state = 13},
+  [242] = {.lex_state = 13},
+  [243] = {.lex_state = 13},
   [244] = {.lex_state = 13},
   [245] = {.lex_state = 13},
-  [246] = {.lex_state = 9},
-  [247] = {.lex_state = 9},
-  [248] = {.lex_state = 33},
-  [249] = {.lex_state = 68},
-  [250] = {.lex_state = 9},
-  [251] = {.lex_state = 9},
-  [252] = {.lex_state = 9},
-  [253] = {.lex_state = 9},
-  [254] = {.lex_state = 9},
-  [255] = {.lex_state = 9},
+  [246] = {.lex_state = 13},
+  [247] = {.lex_state = 22},
+  [248] = {.lex_state = 128},
+  [249] = {.lex_state = 22},
+  [250] = {.lex_state = 13},
+  [251] = {.lex_state = 22},
+  [252] = {.lex_state = 22},
+  [253] = {.lex_state = 22},
+  [254] = {.lex_state = 13},
+  [255] = {.lex_state = 22},
   [256] = {.lex_state = 13},
-  [257] = {.lex_state = 9},
-  [258] = {.lex_state = 9},
-  [259] = {.lex_state = 26},
+  [257] = {.lex_state = 128},
+  [258] = {.lex_state = 22},
+  [259] = {.lex_state = 22},
   [260] = {.lex_state = 13},
-  [261] = {.lex_state = 9},
-  [262] = {.lex_state = 13},
-  [263] = {.lex_state = 9},
-  [264] = {.lex_state = 13},
-  [265] = {.lex_state = 13},
-  [266] = {.lex_state = 13},
-  [267] = {.lex_state = 9},
-  [268] = {.lex_state = 68},
-  [269] = {.lex_state = 13},
-  [270] = {.lex_state = 68},
-  [271] = {.lex_state = 68},
-  [272] = {.lex_state = 68},
-  [273] = {.lex_state = 26},
+  [261] = {.lex_state = 22},
+  [262] = {.lex_state = 22},
+  [263] = {.lex_state = 22},
+  [264] = {.lex_state = 22},
+  [265] = {.lex_state = 22},
+  [266] = {.lex_state = 22},
+  [267] = {.lex_state = 22},
+  [268] = {.lex_state = 13},
+  [269] = {.lex_state = 128},
+  [270] = {.lex_state = 13},
+  [271] = {.lex_state = 13},
+  [272] = {.lex_state = 22},
+  [273] = {.lex_state = 22},
   [274] = {.lex_state = 13},
-  [275] = {.lex_state = 68},
-  [276] = {.lex_state = 33},
-  [277] = {.lex_state = 9},
-  [278] = {.lex_state = 68},
-  [279] = {.lex_state = 9},
-  [280] = {.lex_state = 33},
-  [281] = {.lex_state = 68},
-  [282] = {.lex_state = 68},
-  [283] = {.lex_state = 68},
-  [284] = {.lex_state = 68},
-  [285] = {.lex_state = 33},
-  [286] = {.lex_state = 33},
-  [287] = {.lex_state = 68},
-  [288] = {.lex_state = 68},
-  [289] = {.lex_state = 9},
-  [290] = {.lex_state = 68},
-  [291] = {.lex_state = 68},
-  [292] = {.lex_state = 68},
-  [293] = {.lex_state = 9},
-  [294] = {.lex_state = 68},
-  [295] = {.lex_state = 68},
-  [296] = {.lex_state = 68},
-  [297] = {.lex_state = 68},
-  [298] = {.lex_state = 68},
-  [299] = {.lex_state = 68},
-  [300] = {.lex_state = 68},
-  [301] = {.lex_state = 68},
-  [302] = {.lex_state = 68},
-  [303] = {.lex_state = 68},
-  [304] = {.lex_state = 27},
-  [305] = {.lex_state = 68},
-  [306] = {.lex_state = 35},
-  [307] = {.lex_state = 27},
-  [308] = {.lex_state = 68},
-  [309] = {.lex_state = 68},
-  [310] = {.lex_state = 68},
-  [311] = {.lex_state = 68},
-  [312] = {.lex_state = 68},
-  [313] = {.lex_state = 68},
-  [314] = {.lex_state = 183},
-  [315] = {.lex_state = 9},
-  [316] = {.lex_state = 68},
-  [317] = {.lex_state = 68},
-  [318] = {.lex_state = 68},
-  [319] = {.lex_state = 68},
-  [320] = {.lex_state = 68},
-  [321] = {.lex_state = 68},
-  [322] = {.lex_state = 68},
-  [323] = {.lex_state = 68},
-  [324] = {.lex_state = 68},
-  [325] = {.lex_state = 68},
-  [326] = {.lex_state = 68},
-  [327] = {.lex_state = 68},
-  [328] = {.lex_state = 68},
-  [329] = {.lex_state = 68},
-  [330] = {.lex_state = 68},
-  [331] = {.lex_state = 68},
-  [332] = {.lex_state = 68},
-  [333] = {.lex_state = 68},
-  [334] = {.lex_state = 19},
-  [335] = {.lex_state = 68},
-  [336] = {.lex_state = 68},
-  [337] = {.lex_state = 9},
-  [338] = {.lex_state = 68},
-  [339] = {.lex_state = 9},
-  [340] = {.lex_state = 173},
-  [341] = {.lex_state = 183},
-  [342] = {.lex_state = 68},
-  [343] = {.lex_state = 68},
-  [344] = {.lex_state = 68},
-  [345] = {.lex_state = 68},
-  [346] = {.lex_state = 68},
-  [347] = {.lex_state = 68},
-  [348] = {.lex_state = 173},
-  [349] = {.lex_state = 183},
-  [350] = {.lex_state = 68},
-  [351] = {.lex_state = 173},
-  [352] = {.lex_state = 173},
-  [353] = {.lex_state = 183},
-  [354] = {.lex_state = 173},
-  [355] = {.lex_state = 183},
-  [356] = {.lex_state = 173},
-  [357] = {.lex_state = 183},
-  [358] = {.lex_state = 68},
-  [359] = {.lex_state = 68},
+  [275] = {.lex_state = 13},
+  [276] = {.lex_state = 128},
+  [277] = {.lex_state = 128},
+  [278] = {.lex_state = 128},
+  [279] = {.lex_state = 29},
+  [280] = {.lex_state = 13},
+  [281] = {.lex_state = 22},
+  [282] = {.lex_state = 13},
+  [283] = {.lex_state = 22},
+  [284] = {.lex_state = 128},
+  [285] = {.lex_state = 22},
+  [286] = {.lex_state = 22},
+  [287] = {.lex_state = 128},
+  [288] = {.lex_state = 22},
+  [289] = {.lex_state = 128},
+  [290] = {.lex_state = 128},
+  [291] = {.lex_state = 128},
+  [292] = {.lex_state = 128},
+  [293] = {.lex_state = 128},
+  [294] = {.lex_state = 128},
+  [295] = {.lex_state = 22},
+  [296] = {.lex_state = 22},
+  [297] = {.lex_state = 22},
+  [298] = {.lex_state = 128},
+  [299] = {.lex_state = 23},
+  [300] = {.lex_state = 128},
+  [301] = {.lex_state = 128},
+  [302] = {.lex_state = 128},
+  [303] = {.lex_state = 128},
+  [304] = {.lex_state = 22},
+  [305] = {.lex_state = 128},
+  [306] = {.lex_state = 128},
+  [307] = {.lex_state = 128},
+  [308] = {.lex_state = 128},
+  [309] = {.lex_state = 128},
+  [310] = {.lex_state = 128},
+  [311] = {.lex_state = 128},
+  [312] = {.lex_state = 42},
+  [313] = {.lex_state = 31},
+  [314] = {.lex_state = 128},
+  [315] = {.lex_state = 128},
+  [316] = {.lex_state = 128},
+  [317] = {.lex_state = 128},
+  [318] = {.lex_state = 22},
+  [319] = {.lex_state = 128},
+  [320] = {.lex_state = 128},
+  [321] = {.lex_state = 31},
+  [322] = {.lex_state = 128},
+  [323] = {.lex_state = 128},
+  [324] = {.lex_state = 254},
+  [325] = {.lex_state = 128},
+  [326] = {.lex_state = 44},
+  [327] = {.lex_state = 128},
+  [328] = {.lex_state = 128},
+  [329] = {.lex_state = 44},
+  [330] = {.lex_state = 128},
+  [331] = {.lex_state = 128},
+  [332] = {.lex_state = 128},
+  [333] = {.lex_state = 128},
+  [334] = {.lex_state = 128},
+  [335] = {.lex_state = 128},
+  [336] = {.lex_state = 128},
+  [337] = {.lex_state = 128},
+  [338] = {.lex_state = 128},
+  [339] = {.lex_state = 128},
+  [340] = {.lex_state = 128},
+  [341] = {.lex_state = 128},
+  [342] = {.lex_state = 128},
+  [343] = {.lex_state = 128},
+  [344] = {.lex_state = 254},
+  [345] = {.lex_state = 128},
+  [346] = {.lex_state = 44},
+  [347] = {.lex_state = 244},
+  [348] = {.lex_state = 128},
+  [349] = {.lex_state = 128},
+  [350] = {.lex_state = 128},
+  [351] = {.lex_state = 244},
+  [352] = {.lex_state = 254},
+  [353] = {.lex_state = 128},
+  [354] = {.lex_state = 128},
+  [355] = {.lex_state = 128},
+  [356] = {.lex_state = 128},
+  [357] = {.lex_state = 19},
+  [358] = {.lex_state = 128},
+  [359] = {.lex_state = 244},
+  [360] = {.lex_state = 128},
+  [361] = {.lex_state = 128},
+  [362] = {.lex_state = 128},
+  [363] = {.lex_state = 244},
+  [364] = {.lex_state = 254},
+  [365] = {.lex_state = 244},
+  [366] = {.lex_state = 254},
+  [367] = {.lex_state = 244},
+  [368] = {.lex_state = 254},
+  [369] = {.lex_state = 128},
+  [370] = {.lex_state = 128},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -4783,6 +5227,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_not] = ACTIONS(1),
     [anon_sym_is] = ACTIONS(1),
     [anon_sym_where] = ACTIONS(1),
+    [anon_sym_host] = ACTIONS(1),
+    [anon_sym_host_DASHcontext] = ACTIONS(1),
+    [anon_sym_nth_DASHchild] = ACTIONS(1),
+    [anon_sym_nth_DASHlast_DASHchild] = ACTIONS(1),
     [anon_sym_COLON_COLON] = ACTIONS(1),
     [anon_sym_POUND] = ACTIONS(1),
     [anon_sym_LBRACK] = ACTIONS(1),
@@ -4799,6 +5247,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_PIPE] = ACTIONS(1),
     [anon_sym_LPAREN] = ACTIONS(1),
     [anon_sym_RPAREN] = ACTIONS(1),
+    [anon_sym_even] = ACTIONS(1),
+    [anon_sym_odd] = ACTIONS(1),
+    [anon_sym_of] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
     [sym_important] = ACTIONS(1),
     [anon_sym_LPAREN2] = ACTIONS(1),
@@ -4813,7 +5264,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_float_value_token1] = ACTIONS(1),
     [anon_sym_DASH] = ACTIONS(1),
     [anon_sym_SLASH] = ACTIONS(1),
-    [sym_identifier] = ACTIONS(1),
     [sym_at_keyword] = ACTIONS(1),
     [sym_js_comment] = ACTIONS(3),
     [sym_comment] = ACTIONS(5),
@@ -4822,31 +5272,31 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym___error_recovery] = ACTIONS(1),
   },
   [1] = {
-    [sym_stylesheet] = STATE(319),
-    [sym_import_statement] = STATE(9),
-    [sym_media_statement] = STATE(9),
-    [sym_charset_statement] = STATE(9),
-    [sym_namespace_statement] = STATE(9),
-    [sym_keyframes_statement] = STATE(9),
-    [sym_supports_statement] = STATE(9),
-    [sym_at_rule] = STATE(9),
-    [sym_rule_set] = STATE(9),
-    [sym_selectors] = STATE(310),
-    [sym__selector] = STATE(192),
-    [sym_universal_selector] = STATE(192),
-    [sym_class_selector] = STATE(192),
-    [sym_pseudo_class_selector] = STATE(192),
-    [sym_pseudo_element_selector] = STATE(192),
-    [sym_id_selector] = STATE(192),
-    [sym_attribute_selector] = STATE(192),
-    [sym_child_selector] = STATE(192),
-    [sym_descendant_selector] = STATE(192),
-    [sym_sibling_selector] = STATE(192),
-    [sym_adjacent_sibling_selector] = STATE(192),
-    [sym_namespace_selector] = STATE(192),
-    [sym_declaration] = STATE(9),
-    [sym_string_value] = STATE(192),
-    [aux_sym_stylesheet_repeat1] = STATE(9),
+    [sym_stylesheet] = STATE(355),
+    [sym_import_statement] = STATE(10),
+    [sym_media_statement] = STATE(10),
+    [sym_charset_statement] = STATE(10),
+    [sym_namespace_statement] = STATE(10),
+    [sym_keyframes_statement] = STATE(10),
+    [sym_supports_statement] = STATE(10),
+    [sym_at_rule] = STATE(10),
+    [sym_rule_set] = STATE(10),
+    [sym_selectors] = STATE(322),
+    [sym__selector] = STATE(195),
+    [sym_universal_selector] = STATE(195),
+    [sym_class_selector] = STATE(195),
+    [sym_pseudo_class_selector] = STATE(195),
+    [sym_pseudo_element_selector] = STATE(195),
+    [sym_id_selector] = STATE(195),
+    [sym_attribute_selector] = STATE(195),
+    [sym_child_selector] = STATE(195),
+    [sym_descendant_selector] = STATE(195),
+    [sym_sibling_selector] = STATE(195),
+    [sym_adjacent_sibling_selector] = STATE(195),
+    [sym_namespace_selector] = STATE(195),
+    [sym_declaration] = STATE(10),
+    [sym_string_value] = STATE(195),
+    [aux_sym_stylesheet_repeat1] = STATE(10),
     [ts_builtin_sym_end] = ACTIONS(7),
     [anon_sym_ATimport] = ACTIONS(9),
     [anon_sym_ATmedia] = ACTIONS(11),
@@ -4907,9 +5357,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(59), 1,
       sym_at_keyword,
-    STATE(309), 1,
+    STATE(314), 1,
       sym_selectors,
-    STATE(320), 1,
+    STATE(358), 1,
       sym_last_declaration,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -4917,7 +5367,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(51), 2,
       anon_sym_ATkeyframes,
       aux_sym_keyframes_statement_token1,
-    STATE(4), 11,
+    STATE(3), 11,
       sym_import_statement,
       sym_media_statement,
       sym_charset_statement,
@@ -4929,7 +5379,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_rule_set,
       sym_declaration,
       aux_sym_block_repeat1,
-    STATE(192), 13,
+    STATE(195), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -4978,9 +5428,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_at_keyword,
     ACTIONS(61), 1,
       anon_sym_RBRACE,
-    STATE(309), 1,
+    STATE(314), 1,
       sym_selectors,
-    STATE(318), 1,
+    STATE(332), 1,
       sym_last_declaration,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -4988,7 +5438,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(51), 2,
       anon_sym_ATkeyframes,
       aux_sym_keyframes_statement_token1,
-    STATE(5), 11,
+    STATE(8), 11,
       sym_import_statement,
       sym_media_statement,
       sym_charset_statement,
@@ -5000,7 +5450,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_rule_set,
       sym_declaration,
       aux_sym_block_repeat1,
-    STATE(192), 13,
+    STATE(195), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5049,9 +5499,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_at_keyword,
     ACTIONS(63), 1,
       anon_sym_RBRACE,
-    STATE(309), 1,
+    STATE(314), 1,
       sym_selectors,
-    STATE(321), 1,
+    STATE(338), 1,
       sym_last_declaration,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -5059,7 +5509,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(51), 2,
       anon_sym_ATkeyframes,
       aux_sym_keyframes_statement_token1,
-    STATE(8), 11,
+    STATE(6), 11,
       sym_import_statement,
       sym_media_statement,
       sym_charset_statement,
@@ -5071,7 +5521,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_rule_set,
       sym_declaration,
       aux_sym_block_repeat1,
-    STATE(192), 13,
+    STATE(195), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5120,9 +5570,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_at_keyword,
     ACTIONS(65), 1,
       anon_sym_RBRACE,
-    STATE(309), 1,
+    STATE(314), 1,
       sym_selectors,
-    STATE(346), 1,
+    STATE(333), 1,
       sym_last_declaration,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -5130,7 +5580,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(51), 2,
       anon_sym_ATkeyframes,
       aux_sym_keyframes_statement_token1,
-    STATE(8), 11,
+    STATE(7), 11,
       sym_import_statement,
       sym_media_statement,
       sym_charset_statement,
@@ -5142,7 +5592,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_rule_set,
       sym_declaration,
       aux_sym_block_repeat1,
-    STATE(192), 13,
+    STATE(195), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5191,9 +5641,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_at_keyword,
     ACTIONS(67), 1,
       anon_sym_RBRACE,
-    STATE(309), 1,
+    STATE(314), 1,
       sym_selectors,
-    STATE(322), 1,
+    STATE(360), 1,
       sym_last_declaration,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -5201,7 +5651,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(51), 2,
       anon_sym_ATkeyframes,
       aux_sym_keyframes_statement_token1,
-    STATE(7), 11,
+    STATE(8), 11,
       sym_import_statement,
       sym_media_statement,
       sym_charset_statement,
@@ -5213,7 +5663,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_rule_set,
       sym_declaration,
       aux_sym_block_repeat1,
-    STATE(192), 13,
+    STATE(195), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5262,9 +5712,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_at_keyword,
     ACTIONS(69), 1,
       anon_sym_RBRACE,
-    STATE(309), 1,
+    STATE(314), 1,
       sym_selectors,
-    STATE(313), 1,
+    STATE(337), 1,
       sym_last_declaration,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -5284,7 +5734,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_rule_set,
       sym_declaration,
       aux_sym_block_repeat1,
-    STATE(192), 13,
+    STATE(195), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5333,7 +5783,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_at_keyword,
     ACTIONS(121), 1,
       sym__pseudo_class_selector_colon,
-    STATE(309), 1,
+    STATE(314), 1,
       sym_selectors,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -5353,7 +5803,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_rule_set,
       sym_declaration,
       aux_sym_block_repeat1,
-    STATE(192), 13,
+    STATE(195), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5368,6 +5818,74 @@ static const uint16_t ts_small_parse_table[] = {
       sym_namespace_selector,
       sym_string_value,
   [655] = 22,
+    ACTIONS(124), 1,
+      ts_builtin_sym_end,
+    ACTIONS(126), 1,
+      anon_sym_ATimport,
+    ACTIONS(129), 1,
+      anon_sym_ATmedia,
+    ACTIONS(132), 1,
+      anon_sym_ATcharset,
+    ACTIONS(135), 1,
+      anon_sym_ATnamespace,
+    ACTIONS(141), 1,
+      anon_sym_ATsupports,
+    ACTIONS(144), 1,
+      sym_nesting_selector,
+    ACTIONS(147), 1,
+      anon_sym_STAR,
+    ACTIONS(150), 1,
+      anon_sym_DOT,
+    ACTIONS(153), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(156), 1,
+      anon_sym_POUND,
+    ACTIONS(159), 1,
+      anon_sym_LBRACK,
+    ACTIONS(162), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(165), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(168), 1,
+      sym_identifier,
+    ACTIONS(171), 1,
+      sym_at_keyword,
+    ACTIONS(174), 1,
+      sym__pseudo_class_selector_colon,
+    STATE(322), 1,
+      sym_selectors,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(138), 2,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+    STATE(9), 10,
+      sym_import_statement,
+      sym_media_statement,
+      sym_charset_statement,
+      sym_namespace_statement,
+      sym_keyframes_statement,
+      sym_supports_statement,
+      sym_at_rule,
+      sym_rule_set,
+      sym_declaration,
+      aux_sym_stylesheet_repeat1,
+    STATE(195), 13,
+      sym__selector,
+      sym_universal_selector,
+      sym_class_selector,
+      sym_pseudo_class_selector,
+      sym_pseudo_element_selector,
+      sym_id_selector,
+      sym_attribute_selector,
+      sym_child_selector,
+      sym_descendant_selector,
+      sym_sibling_selector,
+      sym_adjacent_sibling_selector,
+      sym_namespace_selector,
+      sym_string_value,
+  [745] = 22,
     ACTIONS(9), 1,
       anon_sym_ATimport,
     ACTIONS(11), 1,
@@ -5400,9 +5918,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_at_keyword,
     ACTIONS(41), 1,
       sym__pseudo_class_selector_colon,
-    ACTIONS(124), 1,
+    ACTIONS(177), 1,
       ts_builtin_sym_end,
-    STATE(310), 1,
+    STATE(322), 1,
       sym_selectors,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -5410,7 +5928,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(17), 2,
       anon_sym_ATkeyframes,
       aux_sym_keyframes_statement_token1,
-    STATE(10), 10,
+    STATE(9), 10,
       sym_import_statement,
       sym_media_statement,
       sym_charset_statement,
@@ -5421,75 +5939,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_rule_set,
       sym_declaration,
       aux_sym_stylesheet_repeat1,
-    STATE(192), 13,
-      sym__selector,
-      sym_universal_selector,
-      sym_class_selector,
-      sym_pseudo_class_selector,
-      sym_pseudo_element_selector,
-      sym_id_selector,
-      sym_attribute_selector,
-      sym_child_selector,
-      sym_descendant_selector,
-      sym_sibling_selector,
-      sym_adjacent_sibling_selector,
-      sym_namespace_selector,
-      sym_string_value,
-  [745] = 22,
-    ACTIONS(126), 1,
-      ts_builtin_sym_end,
-    ACTIONS(128), 1,
-      anon_sym_ATimport,
-    ACTIONS(131), 1,
-      anon_sym_ATmedia,
-    ACTIONS(134), 1,
-      anon_sym_ATcharset,
-    ACTIONS(137), 1,
-      anon_sym_ATnamespace,
-    ACTIONS(143), 1,
-      anon_sym_ATsupports,
-    ACTIONS(146), 1,
-      sym_nesting_selector,
-    ACTIONS(149), 1,
-      anon_sym_STAR,
-    ACTIONS(152), 1,
-      anon_sym_DOT,
-    ACTIONS(155), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(158), 1,
-      anon_sym_POUND,
-    ACTIONS(161), 1,
-      anon_sym_LBRACK,
-    ACTIONS(164), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(167), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(170), 1,
-      sym_identifier,
-    ACTIONS(173), 1,
-      sym_at_keyword,
-    ACTIONS(176), 1,
-      sym__pseudo_class_selector_colon,
-    STATE(310), 1,
-      sym_selectors,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(140), 2,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-    STATE(10), 10,
-      sym_import_statement,
-      sym_media_statement,
-      sym_charset_statement,
-      sym_namespace_statement,
-      sym_keyframes_statement,
-      sym_supports_statement,
-      sym_at_rule,
-      sym_rule_set,
-      sym_declaration,
-      aux_sym_stylesheet_repeat1,
-    STATE(192), 13,
+    STATE(195), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5540,11 +5990,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(203), 1,
       sym_plain_value,
-    STATE(39), 1,
+    STATE(36), 1,
       aux_sym_postcss_statement_repeat1,
     STATE(40), 1,
       sym_string_value,
-    STATE(170), 8,
+    STATE(179), 8,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -5553,7 +6003,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-    STATE(195), 12,
+    STATE(198), 12,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5603,11 +6053,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_nesting_selector,
     ACTIONS(207), 1,
       anon_sym_RPAREN,
+    STATE(29), 1,
+      aux_sym_postcss_statement_repeat1,
     STATE(40), 1,
       sym_string_value,
-    STATE(43), 1,
-      aux_sym_postcss_statement_repeat1,
-    STATE(170), 8,
+    STATE(179), 8,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -5616,7 +6066,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-    STATE(193), 12,
+    STATE(201), 12,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5666,9 +6116,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_nesting_selector,
     STATE(40), 1,
       sym_string_value,
-    STATE(47), 1,
+    STATE(50), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(170), 8,
+    STATE(179), 8,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -5677,7 +6127,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-    STATE(196), 12,
+    STATE(202), 12,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5725,11 +6175,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(231), 1,
       sym_plain_value,
-    STATE(174), 1,
+    STATE(178), 1,
       sym_namespace_selector,
-    STATE(185), 1,
+    STATE(191), 1,
       sym_string_value,
-    STATE(239), 8,
+    STATE(254), 8,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -5738,7 +6188,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-    STATE(210), 11,
+    STATE(224), 11,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5785,11 +6235,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_important,
     ACTIONS(235), 1,
       sym_plain_value,
-    STATE(174), 1,
+    STATE(178), 1,
       sym_namespace_selector,
-    STATE(185), 1,
+    STATE(191), 1,
       sym_string_value,
-    STATE(245), 8,
+    STATE(256), 8,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -5798,7 +6248,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-    STATE(210), 11,
+    STATE(224), 11,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -5841,21 +6291,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DQUOTE,
     ACTIONS(255), 1,
       sym_identifier,
-    STATE(55), 1,
+    STATE(54), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(113), 1,
+    STATE(117), 1,
       sym_block,
     ACTIONS(241), 2,
       anon_sym_not,
       anon_sym_only,
-    STATE(247), 6,
+    STATE(253), 6,
       sym__query,
       sym_feature_query,
       sym_parenthesized_query,
       sym_binary_query,
       sym_unary_query,
       sym_selector_query,
-    STATE(170), 9,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -5895,14 +6345,14 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(241), 2,
       anon_sym_not,
       anon_sym_only,
-    STATE(293), 6,
+    STATE(304), 6,
       sym__query,
       sym_feature_query,
       sym_parenthesized_query,
       sym_binary_query,
       sym_unary_query,
       sym_selector_query,
-    STATE(266), 9,
+    STATE(275), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -5942,14 +6392,14 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(241), 2,
       anon_sym_not,
       anon_sym_only,
-    STATE(293), 6,
+    STATE(304), 6,
       sym__query,
       sym_feature_query,
       sym_parenthesized_query,
       sym_binary_query,
       sym_unary_query,
       sym_selector_query,
-    STATE(269), 9,
+    STATE(271), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -5992,13 +6442,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(291), 1,
       sym_plain_value,
-    STATE(37), 1,
+    STATE(38), 1,
       aux_sym_declaration_repeat1,
     ACTIONS(285), 3,
       anon_sym_PLUS,
       anon_sym_DASH,
       anon_sym_SLASH,
-    STATE(175), 9,
+    STATE(177), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -6029,6 +6479,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DQUOTE,
     ACTIONS(277), 1,
       anon_sym_COMMA,
+    ACTIONS(279), 1,
+      anon_sym_SEMI,
     ACTIONS(283), 1,
       anon_sym_STAR,
     ACTIONS(289), 1,
@@ -6036,16 +6488,14 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(291), 1,
       sym_plain_value,
     ACTIONS(293), 1,
-      anon_sym_SEMI,
-    ACTIONS(295), 1,
       sym_important,
-    STATE(46), 1,
+    STATE(51), 1,
       aux_sym_declaration_repeat1,
     ACTIONS(285), 3,
       anon_sym_PLUS,
       anon_sym_DASH,
       anon_sym_SLASH,
-    STATE(175), 9,
+    STATE(177), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -6076,23 +6526,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DQUOTE,
     ACTIONS(277), 1,
       anon_sym_COMMA,
-    ACTIONS(279), 1,
-      anon_sym_SEMI,
     ACTIONS(283), 1,
       anon_sym_STAR,
     ACTIONS(289), 1,
       sym_identifier,
     ACTIONS(291), 1,
       sym_plain_value,
+    ACTIONS(295), 1,
+      anon_sym_SEMI,
     ACTIONS(297), 1,
       sym_important,
-    STATE(49), 1,
+    STATE(47), 1,
       aux_sym_declaration_repeat1,
     ACTIONS(285), 3,
       anon_sym_PLUS,
       anon_sym_DASH,
       anon_sym_SLASH,
-    STATE(175), 9,
+    STATE(177), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -6109,7 +6559,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_comment,
     ACTIONS(305), 1,
       anon_sym_LPAREN,
-    STATE(161), 1,
+    STATE(171), 1,
       sym_arguments,
     ACTIONS(303), 2,
       anon_sym_DOT,
@@ -6165,14 +6615,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(311), 1,
       anon_sym_RPAREN,
-    STATE(27), 1,
+    STATE(28), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(281), 1,
+    STATE(294), 1,
       aux_sym_arguments_repeat1,
     ACTIONS(309), 2,
       anon_sym_COMMA,
       anon_sym_SEMI,
-    STATE(170), 9,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -6209,14 +6659,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(313), 1,
       anon_sym_RPAREN,
-    STATE(27), 1,
+    STATE(28), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(282), 1,
+    STATE(284), 1,
       aux_sym_arguments_repeat1,
     ACTIONS(309), 2,
       anon_sym_COMMA,
       anon_sym_SEMI,
-    STATE(170), 9,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -6252,7 +6702,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    STATE(190), 13,
+    STATE(196), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -6293,14 +6743,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(321), 1,
       anon_sym_RPAREN,
-    STATE(27), 1,
+    STATE(28), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(284), 1,
+    STATE(289), 1,
       aux_sym_arguments_repeat1,
     ACTIONS(309), 2,
       anon_sym_COMMA,
       anon_sym_SEMI,
-    STATE(170), 9,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -6310,316 +6760,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [1928] = 15,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(325), 1,
-      anon_sym_POUND,
-    ACTIONS(328), 1,
-      anon_sym_LBRACK,
-    ACTIONS(331), 1,
-      sym_important,
-    ACTIONS(334), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(337), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(340), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(343), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(346), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(349), 1,
-      sym_identifier,
-    ACTIONS(352), 1,
-      sym_plain_value,
-    STATE(27), 1,
-      aux_sym_postcss_statement_repeat1,
-    ACTIONS(323), 3,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_RPAREN,
-    STATE(170), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [1984] = 12,
-    ACTIONS(23), 1,
-      anon_sym_STAR,
-    ACTIONS(25), 1,
-      anon_sym_DOT,
-    ACTIONS(27), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(29), 1,
-      anon_sym_POUND,
-    ACTIONS(31), 1,
-      anon_sym_LBRACK,
-    ACTIONS(33), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(35), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(41), 1,
-      sym__pseudo_class_selector_colon,
-    ACTIONS(319), 1,
-      sym_identifier,
-    ACTIONS(355), 1,
-      sym_nesting_selector,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    STATE(191), 13,
-      sym__selector,
-      sym_universal_selector,
-      sym_class_selector,
-      sym_pseudo_class_selector,
-      sym_pseudo_element_selector,
-      sym_id_selector,
-      sym_attribute_selector,
-      sym_child_selector,
-      sym_descendant_selector,
-      sym_sibling_selector,
-      sym_adjacent_sibling_selector,
-      sym_namespace_selector,
-      sym_string_value,
-  [2034] = 12,
-    ACTIONS(23), 1,
-      anon_sym_STAR,
-    ACTIONS(25), 1,
-      anon_sym_DOT,
-    ACTIONS(27), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(29), 1,
-      anon_sym_POUND,
-    ACTIONS(31), 1,
-      anon_sym_LBRACK,
-    ACTIONS(33), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(35), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(41), 1,
-      sym__pseudo_class_selector_colon,
-    ACTIONS(319), 1,
-      sym_identifier,
-    ACTIONS(357), 1,
-      sym_nesting_selector,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    STATE(89), 13,
-      sym__selector,
-      sym_universal_selector,
-      sym_class_selector,
-      sym_pseudo_class_selector,
-      sym_pseudo_element_selector,
-      sym_id_selector,
-      sym_attribute_selector,
-      sym_child_selector,
-      sym_descendant_selector,
-      sym_sibling_selector,
-      sym_adjacent_sibling_selector,
-      sym_namespace_selector,
-      sym_string_value,
-  [2084] = 12,
-    ACTIONS(23), 1,
-      anon_sym_STAR,
-    ACTIONS(25), 1,
-      anon_sym_DOT,
-    ACTIONS(27), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(29), 1,
-      anon_sym_POUND,
-    ACTIONS(31), 1,
-      anon_sym_LBRACK,
-    ACTIONS(33), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(35), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(41), 1,
-      sym__pseudo_class_selector_colon,
-    ACTIONS(319), 1,
-      sym_identifier,
-    ACTIONS(359), 1,
-      sym_nesting_selector,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    STATE(88), 13,
-      sym__selector,
-      sym_universal_selector,
-      sym_class_selector,
-      sym_pseudo_class_selector,
-      sym_pseudo_element_selector,
-      sym_id_selector,
-      sym_attribute_selector,
-      sym_child_selector,
-      sym_descendant_selector,
-      sym_sibling_selector,
-      sym_adjacent_sibling_selector,
-      sym_namespace_selector,
-      sym_string_value,
-  [2134] = 12,
-    ACTIONS(23), 1,
-      anon_sym_STAR,
-    ACTIONS(25), 1,
-      anon_sym_DOT,
-    ACTIONS(27), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(29), 1,
-      anon_sym_POUND,
-    ACTIONS(31), 1,
-      anon_sym_LBRACK,
-    ACTIONS(33), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(35), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(41), 1,
-      sym__pseudo_class_selector_colon,
-    ACTIONS(319), 1,
-      sym_identifier,
-    ACTIONS(361), 1,
-      sym_nesting_selector,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    STATE(87), 13,
-      sym__selector,
-      sym_universal_selector,
-      sym_class_selector,
-      sym_pseudo_class_selector,
-      sym_pseudo_element_selector,
-      sym_id_selector,
-      sym_attribute_selector,
-      sym_child_selector,
-      sym_descendant_selector,
-      sym_sibling_selector,
-      sym_adjacent_sibling_selector,
-      sym_namespace_selector,
-      sym_string_value,
-  [2184] = 10,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(365), 1,
-      anon_sym_RBRACK,
-    ACTIONS(367), 1,
-      anon_sym_LPAREN,
-    STATE(227), 1,
-      sym_arguments,
-    ACTIONS(301), 2,
-      anon_sym_COMMA,
-      anon_sym_DASH,
-    ACTIONS(303), 2,
-      anon_sym_TILDE,
-      anon_sym_PIPE,
-    ACTIONS(307), 2,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-    ACTIONS(363), 6,
-      anon_sym_EQ,
-      anon_sym_TILDE_EQ,
-      anon_sym_CARET_EQ,
-      anon_sym_PIPE_EQ,
-      anon_sym_STAR_EQ,
-      anon_sym_DOLLAR_EQ,
-    ACTIONS(299), 8,
-      sym__descendant_operator,
-      sym__pseudo_class_selector_colon,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_GT,
-      anon_sym_PLUS,
-  [2230] = 12,
-    ACTIONS(23), 1,
-      anon_sym_STAR,
-    ACTIONS(25), 1,
-      anon_sym_DOT,
-    ACTIONS(27), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(29), 1,
-      anon_sym_POUND,
-    ACTIONS(31), 1,
-      anon_sym_LBRACK,
-    ACTIONS(33), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(35), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(41), 1,
-      sym__pseudo_class_selector_colon,
-    ACTIONS(319), 1,
-      sym_identifier,
-    ACTIONS(369), 1,
-      sym_nesting_selector,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    STATE(86), 13,
-      sym__selector,
-      sym_universal_selector,
-      sym_class_selector,
-      sym_pseudo_class_selector,
-      sym_pseudo_element_selector,
-      sym_id_selector,
-      sym_attribute_selector,
-      sym_child_selector,
-      sym_descendant_selector,
-      sym_sibling_selector,
-      sym_adjacent_sibling_selector,
-      sym_namespace_selector,
-      sym_string_value,
-  [2280] = 16,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(371), 1,
-      anon_sym_COMMA,
-    ACTIONS(376), 1,
-      anon_sym_POUND,
-    ACTIONS(379), 1,
-      anon_sym_LBRACK,
-    ACTIONS(382), 1,
-      sym_important,
-    ACTIONS(385), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(388), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(391), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(394), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(397), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(400), 1,
-      sym_identifier,
-    ACTIONS(403), 1,
-      sym_plain_value,
-    STATE(34), 1,
-      aux_sym_declaration_repeat1,
-    ACTIONS(374), 2,
-      anon_sym_SEMI,
-      anon_sym_RBRACE,
-    STATE(175), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [2338] = 13,
+  [1928] = 13,
     ACTIONS(23), 1,
       anon_sym_STAR,
     ACTIONS(25), 1,
@@ -6638,14 +6779,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym__pseudo_class_selector_colon,
     ACTIONS(211), 1,
       sym_nesting_selector,
-    ACTIONS(406), 1,
+    ACTIONS(323), 1,
       sym_identifier,
-    STATE(177), 1,
+    STATE(178), 1,
       sym_namespace_selector,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    STATE(210), 12,
+    STATE(224), 12,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -6658,7 +6799,48 @@ static const uint16_t ts_small_parse_table[] = {
       sym_sibling_selector,
       sym_adjacent_sibling_selector,
       sym_string_value,
-  [2390] = 15,
+  [1980] = 15,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(327), 1,
+      anon_sym_POUND,
+    ACTIONS(330), 1,
+      anon_sym_LBRACK,
+    ACTIONS(333), 1,
+      sym_important,
+    ACTIONS(336), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(339), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(342), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(345), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(348), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(351), 1,
+      sym_identifier,
+    ACTIONS(354), 1,
+      sym_plain_value,
+    STATE(28), 1,
+      aux_sym_postcss_statement_repeat1,
+    ACTIONS(325), 3,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+    STATE(179), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [2036] = 17,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -6683,13 +6865,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DQUOTE,
     ACTIONS(289), 1,
       sym_identifier,
-    STATE(27), 1,
-      aux_sym_postcss_statement_repeat1,
-    ACTIONS(408), 3,
+    ACTIONS(357), 1,
       anon_sym_COMMA,
-      anon_sym_SEMI,
+    ACTIONS(359), 1,
       anon_sym_RPAREN,
-    STATE(170), 9,
+    STATE(28), 1,
+      aux_sym_postcss_statement_repeat1,
+    STATE(298), 1,
+      aux_sym_pseudo_class_arguments_repeat1,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -6699,7 +6883,321 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [2446] = 17,
+  [2096] = 12,
+    ACTIONS(23), 1,
+      anon_sym_STAR,
+    ACTIONS(25), 1,
+      anon_sym_DOT,
+    ACTIONS(27), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(29), 1,
+      anon_sym_POUND,
+    ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(35), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(41), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(319), 1,
+      sym_identifier,
+    ACTIONS(361), 1,
+      sym_nesting_selector,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    STATE(60), 13,
+      sym__selector,
+      sym_universal_selector,
+      sym_class_selector,
+      sym_pseudo_class_selector,
+      sym_pseudo_element_selector,
+      sym_id_selector,
+      sym_attribute_selector,
+      sym_child_selector,
+      sym_descendant_selector,
+      sym_sibling_selector,
+      sym_adjacent_sibling_selector,
+      sym_namespace_selector,
+      sym_string_value,
+  [2146] = 12,
+    ACTIONS(23), 1,
+      anon_sym_STAR,
+    ACTIONS(25), 1,
+      anon_sym_DOT,
+    ACTIONS(27), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(29), 1,
+      anon_sym_POUND,
+    ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(35), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(41), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(319), 1,
+      sym_identifier,
+    ACTIONS(363), 1,
+      sym_nesting_selector,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    STATE(94), 13,
+      sym__selector,
+      sym_universal_selector,
+      sym_class_selector,
+      sym_pseudo_class_selector,
+      sym_pseudo_element_selector,
+      sym_id_selector,
+      sym_attribute_selector,
+      sym_child_selector,
+      sym_descendant_selector,
+      sym_sibling_selector,
+      sym_adjacent_sibling_selector,
+      sym_namespace_selector,
+      sym_string_value,
+  [2196] = 12,
+    ACTIONS(23), 1,
+      anon_sym_STAR,
+    ACTIONS(25), 1,
+      anon_sym_DOT,
+    ACTIONS(27), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(29), 1,
+      anon_sym_POUND,
+    ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(35), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(41), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(319), 1,
+      sym_identifier,
+    ACTIONS(365), 1,
+      sym_nesting_selector,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    STATE(95), 13,
+      sym__selector,
+      sym_universal_selector,
+      sym_class_selector,
+      sym_pseudo_class_selector,
+      sym_pseudo_element_selector,
+      sym_id_selector,
+      sym_attribute_selector,
+      sym_child_selector,
+      sym_descendant_selector,
+      sym_sibling_selector,
+      sym_adjacent_sibling_selector,
+      sym_namespace_selector,
+      sym_string_value,
+  [2246] = 12,
+    ACTIONS(23), 1,
+      anon_sym_STAR,
+    ACTIONS(25), 1,
+      anon_sym_DOT,
+    ACTIONS(27), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(29), 1,
+      anon_sym_POUND,
+    ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(35), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(41), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(319), 1,
+      sym_identifier,
+    ACTIONS(367), 1,
+      sym_nesting_selector,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    STATE(204), 13,
+      sym__selector,
+      sym_universal_selector,
+      sym_class_selector,
+      sym_pseudo_class_selector,
+      sym_pseudo_element_selector,
+      sym_id_selector,
+      sym_attribute_selector,
+      sym_child_selector,
+      sym_descendant_selector,
+      sym_sibling_selector,
+      sym_adjacent_sibling_selector,
+      sym_namespace_selector,
+      sym_string_value,
+  [2296] = 10,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(371), 1,
+      anon_sym_RBRACK,
+    ACTIONS(373), 1,
+      anon_sym_LPAREN,
+    STATE(237), 1,
+      sym_arguments,
+    ACTIONS(301), 2,
+      anon_sym_COMMA,
+      anon_sym_DASH,
+    ACTIONS(303), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(307), 2,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+    ACTIONS(369), 6,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+    ACTIONS(299), 8,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+  [2342] = 16,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(375), 1,
+      anon_sym_COMMA,
+    ACTIONS(380), 1,
+      anon_sym_POUND,
+    ACTIONS(383), 1,
+      anon_sym_LBRACK,
+    ACTIONS(386), 1,
+      sym_important,
+    ACTIONS(389), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(392), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(395), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(398), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(401), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(404), 1,
+      sym_identifier,
+    ACTIONS(407), 1,
+      sym_plain_value,
+    STATE(35), 1,
+      aux_sym_declaration_repeat1,
+    ACTIONS(378), 2,
+      anon_sym_SEMI,
+      anon_sym_RBRACE,
+    STATE(177), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [2400] = 17,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(189), 1,
+      sym_important,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(203), 1,
+      sym_plain_value,
+    ACTIONS(243), 1,
+      anon_sym_POUND,
+    ACTIONS(245), 1,
+      anon_sym_LBRACK,
+    ACTIONS(251), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(253), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(289), 1,
+      sym_identifier,
+    ACTIONS(357), 1,
+      anon_sym_COMMA,
+    ACTIONS(410), 1,
+      anon_sym_RPAREN,
+    STATE(28), 1,
+      aux_sym_postcss_statement_repeat1,
+    STATE(310), 1,
+      aux_sym_pseudo_class_arguments_repeat1,
+    STATE(179), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [2460] = 15,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(189), 1,
+      sym_important,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(203), 1,
+      sym_plain_value,
+    ACTIONS(243), 1,
+      anon_sym_POUND,
+    ACTIONS(245), 1,
+      anon_sym_LBRACK,
+    ACTIONS(251), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(253), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(289), 1,
+      sym_identifier,
+    STATE(28), 1,
+      aux_sym_postcss_statement_repeat1,
+    ACTIONS(412), 3,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_RPAREN,
+    STATE(179), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [2516] = 17,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -6724,15 +7222,15 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(291), 1,
       sym_plain_value,
-    ACTIONS(410), 1,
-      anon_sym_SEMI,
-    ACTIONS(412), 1,
-      anon_sym_RBRACE,
     ACTIONS(414), 1,
+      anon_sym_SEMI,
+    ACTIONS(416), 1,
+      anon_sym_RBRACE,
+    ACTIONS(418), 1,
       sym_important,
-    STATE(34), 1,
+    STATE(35), 1,
       aux_sym_declaration_repeat1,
-    STATE(175), 9,
+    STATE(177), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -6742,12 +7240,12 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [2506] = 4,
+  [2576] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(418), 8,
+    ACTIONS(422), 8,
       anon_sym_DOT,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
@@ -6756,7 +7254,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(416), 15,
+    ACTIONS(420), 15,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -6772,50 +7270,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [2540] = 17,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(189), 1,
-      sym_important,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(203), 1,
-      sym_plain_value,
-    ACTIONS(243), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      anon_sym_LBRACK,
-    ACTIONS(251), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(289), 1,
-      sym_identifier,
-    ACTIONS(420), 1,
-      anon_sym_COMMA,
-    ACTIONS(422), 1,
-      anon_sym_RPAREN,
-    STATE(27), 1,
-      aux_sym_postcss_statement_repeat1,
-    STATE(290), 1,
-      aux_sym_pseudo_class_arguments_repeat1,
-    STATE(170), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [2600] = 6,
+  [2610] = 6,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -6847,7 +7302,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_PIPE,
       anon_sym_RPAREN,
-  [2638] = 13,
+  [2648] = 12,
     ACTIONS(23), 1,
       anon_sym_STAR,
     ACTIONS(25), 1,
@@ -6864,16 +7319,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DQUOTE,
     ACTIONS(41), 1,
       sym__pseudo_class_selector_colon,
-    ACTIONS(211), 1,
-      sym_nesting_selector,
-    ACTIONS(432), 1,
+    ACTIONS(319), 1,
       sym_identifier,
-    STATE(174), 1,
-      sym_namespace_selector,
+    ACTIONS(432), 1,
+      sym_nesting_selector,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    STATE(210), 12,
+    STATE(87), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -6885,8 +7338,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_descendant_selector,
       sym_sibling_selector,
       sym_adjacent_sibling_selector,
+      sym_namespace_selector,
       sym_string_value,
-  [2690] = 12,
+  [2698] = 12,
     ACTIONS(23), 1,
       anon_sym_STAR,
     ACTIONS(25), 1,
@@ -6910,7 +7364,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    STATE(203), 13,
+    STATE(209), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -6924,50 +7378,45 @@ static const uint16_t ts_small_parse_table[] = {
       sym_adjacent_sibling_selector,
       sym_namespace_selector,
       sym_string_value,
-  [2740] = 17,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(189), 1,
-      sym_important,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(203), 1,
-      sym_plain_value,
-    ACTIONS(243), 1,
+  [2748] = 12,
+    ACTIONS(23), 1,
+      anon_sym_STAR,
+    ACTIONS(25), 1,
+      anon_sym_DOT,
+    ACTIONS(27), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(29), 1,
       anon_sym_POUND,
-    ACTIONS(245), 1,
+    ACTIONS(31), 1,
       anon_sym_LBRACK,
-    ACTIONS(251), 1,
+    ACTIONS(33), 1,
       anon_sym_SQUOTE,
-    ACTIONS(253), 1,
+    ACTIONS(35), 1,
       anon_sym_DQUOTE,
-    ACTIONS(289), 1,
+    ACTIONS(41), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(319), 1,
       sym_identifier,
-    ACTIONS(420), 1,
-      anon_sym_COMMA,
     ACTIONS(436), 1,
-      anon_sym_RPAREN,
-    STATE(27), 1,
-      aux_sym_postcss_statement_repeat1,
-    STATE(299), 1,
-      aux_sym_pseudo_class_arguments_repeat1,
-    STATE(170), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
+      sym_nesting_selector,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    STATE(197), 13,
+      sym__selector,
+      sym_universal_selector,
+      sym_class_selector,
+      sym_pseudo_class_selector,
+      sym_pseudo_element_selector,
+      sym_id_selector,
+      sym_attribute_selector,
+      sym_child_selector,
+      sym_descendant_selector,
+      sym_sibling_selector,
+      sym_adjacent_sibling_selector,
+      sym_namespace_selector,
       sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [2800] = 12,
+  [2798] = 12,
     ACTIONS(23), 1,
       anon_sym_STAR,
     ACTIONS(25), 1,
@@ -6991,7 +7440,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    STATE(83), 13,
+    STATE(93), 13,
       sym__selector,
       sym_universal_selector,
       sym_class_selector,
@@ -7005,18 +7454,57 @@ static const uint16_t ts_small_parse_table[] = {
       sym_adjacent_sibling_selector,
       sym_namespace_selector,
       sym_string_value,
-  [2850] = 5,
-    ACTIONS(444), 1,
-      anon_sym_LPAREN,
-    STATE(65), 1,
-      sym_pseudo_element_arguments,
+  [2848] = 13,
+    ACTIONS(23), 1,
+      anon_sym_STAR,
+    ACTIONS(25), 1,
+      anon_sym_DOT,
+    ACTIONS(27), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(29), 1,
+      anon_sym_POUND,
+    ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(33), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(35), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(41), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(211), 1,
+      sym_nesting_selector,
+    ACTIONS(440), 1,
+      sym_identifier,
+    STATE(183), 1,
+      sym_namespace_selector,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(442), 2,
+    STATE(224), 12,
+      sym__selector,
+      sym_universal_selector,
+      sym_class_selector,
+      sym_pseudo_class_selector,
+      sym_pseudo_element_selector,
+      sym_id_selector,
+      sym_attribute_selector,
+      sym_child_selector,
+      sym_descendant_selector,
+      sym_sibling_selector,
+      sym_adjacent_sibling_selector,
+      sym_string_value,
+  [2900] = 5,
+    ACTIONS(446), 1,
+      anon_sym_LPAREN,
+    STATE(67), 1,
+      sym_pseudo_class_arguments,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(444), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(440), 18,
+    ACTIONS(442), 18,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -7035,7 +7523,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [2885] = 16,
+  [2935] = 16,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -7060,13 +7548,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(291), 1,
       sym_plain_value,
-    ACTIONS(446), 1,
-      anon_sym_SEMI,
     ACTIONS(448), 1,
+      anon_sym_SEMI,
+    ACTIONS(450), 1,
       sym_important,
-    STATE(34), 1,
+    STATE(35), 1,
       aux_sym_declaration_repeat1,
-    STATE(175), 9,
+    STATE(177), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -7076,50 +7564,10 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [2942] = 15,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(189), 1,
-      sym_important,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(203), 1,
-      sym_plain_value,
-    ACTIONS(243), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      anon_sym_LBRACK,
-    ACTIONS(251), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(289), 1,
-      sym_identifier,
-    STATE(27), 1,
-      aux_sym_postcss_statement_repeat1,
-    ACTIONS(450), 2,
-      anon_sym_COMMA,
-      anon_sym_RPAREN,
-    STATE(170), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [2997] = 5,
-    ACTIONS(444), 1,
+  [2992] = 5,
+    ACTIONS(456), 1,
       anon_sym_LPAREN,
-    STATE(70), 1,
+    STATE(74), 1,
       sym_pseudo_element_arguments,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -7146,52 +7594,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3032] = 16,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(243), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      anon_sym_LBRACK,
-    ACTIONS(251), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(277), 1,
-      anon_sym_COMMA,
-    ACTIONS(289), 1,
-      sym_identifier,
-    ACTIONS(291), 1,
-      sym_plain_value,
-    ACTIONS(410), 1,
-      anon_sym_SEMI,
+  [3027] = 5,
     ACTIONS(456), 1,
-      sym_important,
-    STATE(34), 1,
-      aux_sym_declaration_repeat1,
-    STATE(175), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [3089] = 5,
-    ACTIONS(462), 1,
       anon_sym_LPAREN,
-    STATE(64), 1,
-      sym_pseudo_class_arguments,
+    STATE(68), 1,
+      sym_pseudo_element_arguments,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7217,37 +7624,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3124] = 5,
-    ACTIONS(462), 1,
-      anon_sym_LPAREN,
-    STATE(61), 1,
-      sym_pseudo_class_arguments,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(466), 2,
-      anon_sym_TILDE,
-      anon_sym_PIPE,
-    ACTIONS(464), 18,
-      sym__descendant_operator,
-      sym__pseudo_class_selector_colon,
-      anon_sym_COMMA,
-      anon_sym_LBRACE,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_EQ,
-      anon_sym_TILDE_EQ,
-      anon_sym_CARET_EQ,
-      anon_sym_PIPE_EQ,
-      anon_sym_STAR_EQ,
-      anon_sym_DOLLAR_EQ,
-      anon_sym_RBRACK,
-      anon_sym_GT,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-  [3159] = 15,
+  [3062] = 15,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -7272,11 +7649,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DQUOTE,
     ACTIONS(289), 1,
       sym_identifier,
-    ACTIONS(468), 1,
-      anon_sym_RPAREN,
-    STATE(24), 1,
+    STATE(28), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(170), 9,
+    ACTIONS(462), 2,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -7286,14 +7664,85 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [3213] = 8,
+  [3117] = 16,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(243), 1,
+      anon_sym_POUND,
+    ACTIONS(245), 1,
+      anon_sym_LBRACK,
+    ACTIONS(251), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(253), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(277), 1,
+      anon_sym_COMMA,
+    ACTIONS(289), 1,
+      sym_identifier,
+    ACTIONS(291), 1,
+      sym_plain_value,
+    ACTIONS(414), 1,
+      anon_sym_SEMI,
+    ACTIONS(464), 1,
+      sym_important,
+    STATE(35), 1,
+      aux_sym_declaration_repeat1,
+    STATE(177), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [3174] = 5,
+    ACTIONS(446), 1,
+      anon_sym_LPAREN,
+    STATE(63), 1,
+      sym_pseudo_class_arguments,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(468), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(466), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [3209] = 8,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
     ACTIONS(305), 1,
       anon_sym_LPAREN,
-    STATE(161), 1,
+    STATE(171), 1,
       sym_arguments,
     ACTIONS(472), 2,
       anon_sym_and,
@@ -7318,7 +7767,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-  [3253] = 15,
+  [3249] = 15,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -7344,10 +7793,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(289), 1,
       sym_identifier,
     ACTIONS(474), 1,
-      anon_sym_RPAREN,
-    STATE(23), 1,
+      anon_sym_SEMI,
+    STATE(28), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(170), 9,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -7357,7 +7806,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [3307] = 15,
+  [3303] = 15,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -7383,10 +7832,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(289), 1,
       sym_identifier,
     ACTIONS(476), 1,
-      anon_sym_SEMI,
-    STATE(27), 1,
+      anon_sym_RPAREN,
+    STATE(28), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(170), 9,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -7396,7 +7845,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [3361] = 15,
+  [3357] = 15,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -7423,9 +7872,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(478), 1,
       anon_sym_RPAREN,
-    STATE(26), 1,
+    STATE(24), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(170), 9,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -7435,7 +7884,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [3415] = 15,
+  [3411] = 15,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -7462,9 +7911,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_identifier,
     ACTIONS(480), 1,
       anon_sym_RPAREN,
-    STATE(27), 1,
+    STATE(26), 1,
       aux_sym_postcss_statement_repeat1,
-    STATE(170), 9,
+    STATE(179), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -7474,14 +7923,53 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [3469] = 3,
+  [3465] = 15,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(189), 1,
+      sym_important,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(203), 1,
+      sym_plain_value,
+    ACTIONS(243), 1,
+      anon_sym_POUND,
+    ACTIONS(245), 1,
+      anon_sym_LBRACK,
+    ACTIONS(251), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(253), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(289), 1,
+      sym_identifier,
+    ACTIONS(482), 1,
+      anon_sym_RPAREN,
+    STATE(23), 1,
+      aux_sym_postcss_statement_repeat1,
+    STATE(179), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [3519] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(484), 2,
+    ACTIONS(486), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(482), 18,
+    ACTIONS(484), 18,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -7500,45 +7988,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3498] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(488), 2,
-      anon_sym_TILDE,
-      anon_sym_PIPE,
-    ACTIONS(486), 18,
-      sym__descendant_operator,
-      sym__pseudo_class_selector_colon,
-      anon_sym_COMMA,
-      anon_sym_LBRACE,
+  [3548] = 4,
+    ACTIONS(490), 1,
       anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_EQ,
-      anon_sym_TILDE_EQ,
-      anon_sym_CARET_EQ,
-      anon_sym_PIPE_EQ,
-      anon_sym_STAR_EQ,
-      anon_sym_DOLLAR_EQ,
-      anon_sym_RBRACK,
-      anon_sym_GT,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-  [3527] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
     ACTIONS(492), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(490), 18,
+    ACTIONS(488), 17,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
       anon_sym_LBRACE,
-      anon_sym_DOT,
       anon_sym_COLON_COLON,
       anon_sym_POUND,
       anon_sym_LBRACK,
@@ -7552,7 +8015,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3556] = 3,
+  [3579] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7578,44 +8041,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3585] = 14,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(189), 1,
-      sym_important,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(203), 1,
-      sym_plain_value,
-    ACTIONS(243), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      anon_sym_LBRACK,
-    ACTIONS(251), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(289), 1,
-      sym_identifier,
-    STATE(57), 1,
-      aux_sym_postcss_statement_repeat1,
-    STATE(170), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [3636] = 3,
+  [3608] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7641,7 +8067,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3665] = 3,
+  [3637] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7667,7 +8093,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3694] = 3,
+  [3666] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7693,7 +8119,44 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3723] = 3,
+  [3695] = 14,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(189), 1,
+      sym_important,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(203), 1,
+      sym_plain_value,
+    ACTIONS(243), 1,
+      anon_sym_POUND,
+    ACTIONS(245), 1,
+      anon_sym_LBRACK,
+    ACTIONS(251), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(253), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(289), 1,
+      sym_identifier,
+    STATE(55), 1,
+      aux_sym_postcss_statement_repeat1,
+    STATE(179), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [3746] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7719,7 +8182,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3752] = 3,
+  [3775] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7745,7 +8208,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3781] = 3,
+  [3804] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7771,44 +8234,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3810] = 14,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(189), 1,
-      sym_important,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(203), 1,
-      sym_plain_value,
-    ACTIONS(243), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      anon_sym_LBRACK,
-    ACTIONS(251), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(289), 1,
-      sym_identifier,
-    STATE(36), 1,
-      aux_sym_postcss_statement_repeat1,
-    STATE(170), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [3861] = 3,
+  [3833] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7834,7 +8260,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3890] = 3,
+  [3862] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7860,7 +8286,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3919] = 3,
+  [3891] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7886,33 +8312,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [3948] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(418), 2,
-      anon_sym_TILDE,
-      anon_sym_PIPE,
-    ACTIONS(416), 18,
-      sym__descendant_operator,
-      sym__pseudo_class_selector_colon,
-      anon_sym_COMMA,
-      anon_sym_LBRACE,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_EQ,
-      anon_sym_TILDE_EQ,
-      anon_sym_CARET_EQ,
-      anon_sym_PIPE_EQ,
-      anon_sym_STAR_EQ,
-      anon_sym_DOLLAR_EQ,
-      anon_sym_RBRACK,
-      anon_sym_GT,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-  [3977] = 3,
+  [3920] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7938,7 +8338,44 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4006] = 3,
+  [3949] = 14,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(189), 1,
+      sym_important,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(203), 1,
+      sym_plain_value,
+    ACTIONS(243), 1,
+      anon_sym_POUND,
+    ACTIONS(245), 1,
+      anon_sym_LBRACK,
+    ACTIONS(251), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(253), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(289), 1,
+      sym_identifier,
+    STATE(37), 1,
+      aux_sym_postcss_statement_repeat1,
+    STATE(179), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [4000] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7964,7 +8401,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4035] = 3,
+  [4029] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -7990,7 +8427,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4064] = 3,
+  [4058] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -8016,7 +8453,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4093] = 3,
+  [4087] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -8042,7 +8479,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4122] = 3,
+  [4116] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -8068,36 +8505,33 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4151] = 6,
-    ACTIONS(3), 1,
+  [4145] = 3,
+    ACTIONS(5), 2,
       sym_js_comment,
-    ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(305), 1,
-      anon_sym_LPAREN,
-    STATE(161), 1,
-      sym_arguments,
-    ACTIONS(307), 8,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-      aux_sym_integer_value_token1,
-      aux_sym_float_value_token1,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-      sym_plain_value,
-    ACTIONS(301), 10,
+    ACTIONS(422), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(420), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
       anon_sym_POUND,
       anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
       anon_sym_RPAREN,
-      sym_important,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-  [4186] = 3,
+  [4174] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -8123,7 +8557,140 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4215] = 3,
+  [4203] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(564), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(562), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [4232] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(568), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(566), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [4261] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(572), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(570), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [4290] = 6,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(305), 1,
+      anon_sym_LPAREN,
+    STATE(171), 1,
+      sym_arguments,
+    ACTIONS(307), 8,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+      aux_sym_integer_value_token1,
+      aux_sym_float_value_token1,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+      sym_plain_value,
+    ACTIONS(301), 10,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_RPAREN,
+      sym_important,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+  [4325] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(576), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(574), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [4354] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -8149,16 +8716,16 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4244] = 4,
-    ACTIONS(564), 1,
+  [4383] = 4,
+    ACTIONS(490), 1,
       anon_sym_DOT,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(566), 2,
+    ACTIONS(580), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(562), 17,
+    ACTIONS(578), 17,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -8176,40 +8743,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4275] = 3,
+  [4414] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(570), 2,
+    ACTIONS(584), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(568), 18,
-      sym__descendant_operator,
-      sym__pseudo_class_selector_colon,
-      anon_sym_COMMA,
-      anon_sym_LBRACE,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_EQ,
-      anon_sym_TILDE_EQ,
-      anon_sym_CARET_EQ,
-      anon_sym_PIPE_EQ,
-      anon_sym_STAR_EQ,
-      anon_sym_DOLLAR_EQ,
-      anon_sym_RBRACK,
-      anon_sym_GT,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-  [4304] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(574), 2,
-      anon_sym_TILDE,
-      anon_sym_PIPE,
-    ACTIONS(572), 18,
+    ACTIONS(582), 18,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -8228,16 +8769,120 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4333] = 4,
-    ACTIONS(564), 1,
+  [4443] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(588), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(586), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [4472] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(592), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(590), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [4501] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(596), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(594), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [4530] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(600), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(598), 18,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+      anon_sym_RBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+  [4559] = 4,
+    ACTIONS(490), 1,
       anon_sym_DOT,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(578), 2,
+    ACTIONS(604), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(576), 17,
+    ACTIONS(602), 17,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -8255,16 +8900,16 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4364] = 4,
-    ACTIONS(564), 1,
+  [4590] = 4,
+    ACTIONS(490), 1,
       anon_sym_DOT,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(582), 2,
+    ACTIONS(608), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(580), 17,
+    ACTIONS(606), 17,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -8282,16 +8927,16 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4395] = 4,
-    ACTIONS(564), 1,
+  [4621] = 4,
+    ACTIONS(490), 1,
       anon_sym_DOT,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(586), 2,
+    ACTIONS(612), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(584), 17,
+    ACTIONS(610), 17,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -8309,38 +8954,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_GT,
       anon_sym_PLUS,
       anon_sym_RPAREN,
-  [4426] = 4,
-    ACTIONS(564), 1,
-      anon_sym_DOT,
+  [4652] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(590), 2,
-      anon_sym_TILDE,
-      anon_sym_PIPE,
-    ACTIONS(588), 17,
-      sym__descendant_operator,
-      sym__pseudo_class_selector_colon,
-      anon_sym_COMMA,
-      anon_sym_LBRACE,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_EQ,
-      anon_sym_TILDE_EQ,
-      anon_sym_CARET_EQ,
-      anon_sym_PIPE_EQ,
-      anon_sym_STAR_EQ,
-      anon_sym_DOLLAR_EQ,
-      anon_sym_RBRACK,
-      anon_sym_GT,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-  [4457] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(592), 8,
+    ACTIONS(614), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -8349,7 +8967,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(594), 11,
+    ACTIONS(616), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -8361,142 +8979,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [4485] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(598), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(596), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [4513] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(602), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(600), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [4541] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(606), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(604), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [4569] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(610), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(608), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [4597] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(225), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(227), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(257), 1,
-      anon_sym_POUND,
-    ACTIONS(259), 1,
-      anon_sym_LBRACK,
-    ACTIONS(265), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(267), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(612), 1,
-      sym_important,
-    ACTIONS(614), 1,
-      sym_identifier,
-    ACTIONS(616), 1,
-      sym_plain_value,
-    STATE(265), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [4645] = 3,
+  [4680] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -8521,32 +9004,42 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [4673] = 3,
-    ACTIONS(5), 2,
+  [4708] = 13,
+    ACTIONS(3), 1,
       sym_js_comment,
+    ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(624), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(622), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(243), 1,
       anon_sym_POUND,
+    ACTIONS(245), 1,
       anon_sym_LBRACK,
+    ACTIONS(251), 1,
       anon_sym_SQUOTE,
+    ACTIONS(253), 1,
       anon_sym_DQUOTE,
+    ACTIONS(289), 1,
       sym_identifier,
-  [4701] = 3,
+    ACTIONS(622), 1,
+      sym_important,
+    ACTIONS(624), 1,
+      sym_plain_value,
+    STATE(180), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [4756] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -8571,7 +9064,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [4729] = 3,
+  [4784] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -8596,32 +9089,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [4757] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(636), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(634), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [4785] = 13,
+  [4812] = 13,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -8640,13 +9108,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
     ACTIONS(267), 1,
       anon_sym_DQUOTE,
-    ACTIONS(614), 1,
+    ACTIONS(634), 1,
+      sym_important,
+    ACTIONS(636), 1,
       sym_identifier,
     ACTIONS(638), 1,
-      sym_important,
-    ACTIONS(640), 1,
       sym_plain_value,
-    STATE(260), 9,
+    STATE(280), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -8656,11 +9124,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [4833] = 3,
+  [4860] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(644), 8,
+    ACTIONS(642), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -8669,7 +9137,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(642), 11,
+    ACTIONS(640), 11,
       sym__pseudo_class_selector_colon,
       ts_builtin_sym_end,
       sym_nesting_selector,
@@ -8681,107 +9149,42 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [4861] = 3,
-    ACTIONS(5), 2,
+  [4888] = 13,
+    ACTIONS(3), 1,
       sym_js_comment,
+    ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(648), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(646), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
+    ACTIONS(219), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(225), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(227), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(257), 1,
       anon_sym_POUND,
+    ACTIONS(259), 1,
       anon_sym_LBRACK,
+    ACTIONS(265), 1,
       anon_sym_SQUOTE,
+    ACTIONS(267), 1,
       anon_sym_DQUOTE,
+    ACTIONS(636), 1,
       sym_identifier,
-  [4889] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(650), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(652), 11,
-      sym__pseudo_class_selector_colon,
-      anon_sym_RBRACE,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [4917] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(656), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(654), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [4945] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(660), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(658), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [4973] = 13,
+    ACTIONS(644), 1,
+      sym_important,
+    ACTIONS(646), 1,
+      sym_plain_value,
+    STATE(282), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [4936] = 13,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -8802,154 +9205,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DQUOTE,
     ACTIONS(289), 1,
       sym_identifier,
-    ACTIONS(662), 1,
+    ACTIONS(648), 1,
       sym_important,
-    ACTIONS(664), 1,
-      sym_plain_value,
-    STATE(171), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [5021] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(668), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(666), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [5049] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(672), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(670), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [5077] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(676), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(674), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [5105] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(678), 1,
-      anon_sym_POUND,
-    ACTIONS(680), 1,
-      anon_sym_LBRACK,
-    ACTIONS(682), 1,
-      sym_important,
-    ACTIONS(684), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(686), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(688), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(690), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(692), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(694), 1,
-      sym_identifier,
-    ACTIONS(696), 1,
-      sym_plain_value,
-    STATE(217), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [5153] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(243), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      anon_sym_LBRACK,
-    ACTIONS(251), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(289), 1,
-      sym_identifier,
-    ACTIONS(698), 1,
-      sym_important,
-    ACTIONS(700), 1,
+    ACTIONS(650), 1,
       sym_plain_value,
     STATE(19), 9,
       sym__value,
@@ -8961,11 +9219,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [5201] = 3,
+  [4984] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(620), 8,
+    ACTIONS(652), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -8974,7 +9232,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(618), 11,
+    ACTIONS(654), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -8986,11 +9244,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5229] = 3,
+  [5012] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(598), 8,
+    ACTIONS(658), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -8999,9 +9257,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(596), 11,
+    ACTIONS(656), 11,
       sym__pseudo_class_selector_colon,
-      anon_sym_RBRACE,
+      ts_builtin_sym_end,
       sym_nesting_selector,
       anon_sym_STAR,
       anon_sym_DOT,
@@ -9011,7 +9269,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5257] = 3,
+  [5040] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -9024,7 +9282,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(658), 11,
+    ACTIONS(662), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9036,7 +9294,67 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5285] = 13,
+  [5068] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(666), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(664), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [5096] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(668), 1,
+      anon_sym_POUND,
+    ACTIONS(670), 1,
+      anon_sym_LBRACK,
+    ACTIONS(672), 1,
+      sym_important,
+    ACTIONS(674), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(676), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(678), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(680), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(682), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(684), 1,
+      sym_identifier,
+    ACTIONS(686), 1,
+      sym_plain_value,
+    STATE(232), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [5144] = 13,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -9055,13 +9373,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
     ACTIONS(267), 1,
       anon_sym_DQUOTE,
-    ACTIONS(614), 1,
+    ACTIONS(636), 1,
       sym_identifier,
-    ACTIONS(702), 1,
+    ACTIONS(688), 1,
       sym_important,
-    ACTIONS(704), 1,
+    ACTIONS(690), 1,
       sym_plain_value,
-    STATE(228), 9,
+    STATE(250), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -9071,32 +9389,157 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [5333] = 13,
+  [5192] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(694), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(692), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [5220] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(614), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(616), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [5248] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(698), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(696), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [5276] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(702), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(700), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [5304] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(706), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(704), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [5332] = 13,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(678), 1,
+    ACTIONS(668), 1,
       anon_sym_POUND,
-    ACTIONS(680), 1,
+    ACTIONS(670), 1,
       anon_sym_LBRACK,
-    ACTIONS(684), 1,
+    ACTIONS(674), 1,
       anon_sym_LPAREN2,
-    ACTIONS(686), 1,
+    ACTIONS(676), 1,
       anon_sym_SQUOTE,
-    ACTIONS(688), 1,
+    ACTIONS(678), 1,
       anon_sym_DQUOTE,
-    ACTIONS(690), 1,
+    ACTIONS(680), 1,
       aux_sym_integer_value_token1,
-    ACTIONS(692), 1,
+    ACTIONS(682), 1,
       aux_sym_float_value_token1,
-    ACTIONS(694), 1,
+    ACTIONS(684), 1,
       sym_identifier,
-    ACTIONS(706), 1,
-      sym_important,
     ACTIONS(708), 1,
+      sym_important,
+    ACTIONS(710), 1,
       sym_plain_value,
-    STATE(182), 9,
+    STATE(188), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -9106,11 +9549,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [5381] = 3,
+  [5380] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(710), 8,
+    ACTIONS(660), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9119,7 +9562,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(712), 11,
+    ACTIONS(662), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9131,11 +9574,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5409] = 3,
+  [5408] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(714), 8,
+    ACTIONS(694), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9144,7 +9587,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(716), 11,
+    ACTIONS(692), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9156,11 +9599,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5437] = 3,
+  [5436] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(602), 8,
+    ACTIONS(666), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9169,7 +9612,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(600), 11,
+    ACTIONS(664), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9181,11 +9624,46 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5465] = 3,
+  [5464] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(225), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(227), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(257), 1,
+      anon_sym_POUND,
+    ACTIONS(259), 1,
+      anon_sym_LBRACK,
+    ACTIONS(265), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(267), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(636), 1,
+      sym_identifier,
+    ACTIONS(712), 1,
+      sym_important,
+    ACTIONS(714), 1,
+      sym_plain_value,
+    STATE(241), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [5512] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(606), 8,
+    ACTIONS(706), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9194,7 +9672,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(604), 11,
+    ACTIONS(704), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9206,11 +9684,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5493] = 3,
+  [5540] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(672), 8,
+    ACTIONS(716), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9219,7 +9697,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(670), 11,
+    ACTIONS(718), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9231,11 +9709,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5521] = 3,
+  [5568] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(718), 8,
+    ACTIONS(720), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9244,7 +9722,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(720), 11,
+    ACTIONS(722), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9256,11 +9734,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5549] = 3,
+  [5596] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(610), 8,
+    ACTIONS(724), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9269,7 +9747,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(608), 11,
+    ACTIONS(726), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9281,11 +9759,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5577] = 3,
+  [5624] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(628), 8,
+    ACTIONS(728), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9294,7 +9772,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(626), 11,
+    ACTIONS(730), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9306,11 +9784,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5605] = 3,
+  [5652] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(636), 8,
+    ACTIONS(698), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9319,7 +9797,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(634), 11,
+    ACTIONS(696), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9331,11 +9809,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5633] = 3,
+  [5680] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(648), 8,
+    ACTIONS(732), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9344,7 +9822,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(646), 11,
+    ACTIONS(734), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9356,11 +9834,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5661] = 3,
+  [5708] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(668), 8,
+    ACTIONS(736), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9369,7 +9847,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(666), 11,
+    ACTIONS(738), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9381,11 +9859,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5689] = 3,
+  [5736] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(722), 8,
+    ACTIONS(740), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9394,7 +9872,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(724), 11,
+    ACTIONS(742), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9406,11 +9884,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5717] = 3,
+  [5764] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(726), 8,
+    ACTIONS(744), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9419,7 +9897,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(728), 11,
+    ACTIONS(746), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9431,11 +9909,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5745] = 3,
+  [5792] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(624), 8,
+    ACTIONS(748), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9444,7 +9922,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(622), 11,
+    ACTIONS(750), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9456,7 +9934,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5773] = 3,
+  [5820] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -9481,46 +9959,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5801] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(225), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(227), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(257), 1,
-      anon_sym_POUND,
-    ACTIONS(259), 1,
-      anon_sym_LBRACK,
-    ACTIONS(265), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(267), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(614), 1,
-      sym_identifier,
-    ACTIONS(730), 1,
-      sym_important,
-    ACTIONS(732), 1,
-      sym_plain_value,
-    STATE(256), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [5849] = 3,
+  [5848] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(656), 8,
+    ACTIONS(702), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9529,7 +9972,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(654), 11,
+    ACTIONS(700), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9541,11 +9984,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5877] = 3,
+  [5876] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(676), 8,
+    ACTIONS(752), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -9554,7 +9997,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(674), 11,
+    ACTIONS(754), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -9566,61 +10009,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5905] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(738), 1,
-      sym_unit,
-    ACTIONS(736), 7,
-      anon_sym_PLUS,
-      aux_sym_integer_value_token1,
-      aux_sym_float_value_token1,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-      sym_plain_value,
-    ACTIONS(734), 11,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_RPAREN,
-      sym_important,
-      anon_sym_LPAREN2,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-  [5937] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(744), 1,
-      sym_unit,
-    ACTIONS(742), 7,
-      anon_sym_PLUS,
-      aux_sym_integer_value_token1,
-      aux_sym_float_value_token1,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-      sym_plain_value,
-    ACTIONS(740), 11,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_RBRACE,
-      anon_sym_STAR,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_RPAREN,
-      sym_important,
-      anon_sym_LPAREN2,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-  [5969] = 3,
+  [5904] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -9645,7 +10034,82 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [5997] = 13,
+  [5932] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(660), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(662), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [5960] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(642), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(640), 11,
+      sym__pseudo_class_selector_colon,
+      anon_sym_RBRACE,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [5988] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(658), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(656), 11,
+      sym__pseudo_class_selector_colon,
+      anon_sym_RBRACE,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6016] = 13,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -9666,231 +10130,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DQUOTE,
     ACTIONS(289), 1,
       sym_identifier,
-    ACTIONS(746), 1,
-      sym_important,
-    ACTIONS(748), 1,
-      sym_plain_value,
-    STATE(165), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [6045] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(225), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(227), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(257), 1,
-      anon_sym_POUND,
-    ACTIONS(259), 1,
-      anon_sym_LBRACK,
-    ACTIONS(265), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(267), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(614), 1,
-      sym_identifier,
-    ACTIONS(750), 1,
-      sym_important,
-    ACTIONS(752), 1,
-      sym_plain_value,
-    STATE(244), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [6093] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(718), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(720), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [6121] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(592), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(594), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [6149] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(710), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(712), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [6177] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(722), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(724), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [6205] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(714), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(716), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [6233] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(726), 8,
-      anon_sym_ATimport,
-      anon_sym_ATmedia,
-      anon_sym_ATcharset,
-      anon_sym_ATnamespace,
-      anon_sym_ATkeyframes,
-      aux_sym_keyframes_statement_token1,
-      anon_sym_ATsupports,
-      sym_at_keyword,
-    ACTIONS(728), 11,
-      sym__pseudo_class_selector_colon,
-      ts_builtin_sym_end,
-      sym_nesting_selector,
-      anon_sym_STAR,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-      sym_identifier,
-  [6261] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(243), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      anon_sym_LBRACK,
-    ACTIONS(251), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(289), 1,
-      sym_identifier,
-    ACTIONS(754), 1,
-      sym_important,
     ACTIONS(756), 1,
+      sym_important,
+    ACTIONS(758), 1,
       sym_plain_value,
-    STATE(20), 9,
+    STATE(21), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -9900,32 +10144,111 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [6309] = 13,
+  [6064] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(678), 1,
-      anon_sym_POUND,
-    ACTIONS(680), 1,
-      anon_sym_LBRACK,
-    ACTIONS(684), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(686), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(688), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(690), 1,
+    ACTIONS(764), 1,
+      sym_unit,
+    ACTIONS(762), 7,
+      anon_sym_PLUS,
       aux_sym_integer_value_token1,
-    ACTIONS(692), 1,
       aux_sym_float_value_token1,
-    ACTIONS(694), 1,
+      anon_sym_DASH,
+      anon_sym_SLASH,
       sym_identifier,
-    ACTIONS(758), 1,
-      sym_important,
-    ACTIONS(760), 1,
       sym_plain_value,
-    STATE(183), 9,
+    ACTIONS(760), 11,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_RPAREN,
+      sym_important,
+      anon_sym_LPAREN2,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+  [6096] = 5,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(770), 1,
+      sym_unit,
+    ACTIONS(768), 7,
+      anon_sym_PLUS,
+      aux_sym_integer_value_token1,
+      aux_sym_float_value_token1,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+      sym_plain_value,
+    ACTIONS(766), 11,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_RBRACE,
+      anon_sym_STAR,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_RPAREN,
+      sym_important,
+      anon_sym_LPAREN2,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+  [6128] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(752), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(754), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6156] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(243), 1,
+      anon_sym_POUND,
+    ACTIONS(245), 1,
+      anon_sym_LBRACK,
+    ACTIONS(251), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(253), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(289), 1,
+      sym_identifier,
+    ACTIONS(772), 1,
+      sym_important,
+    ACTIONS(774), 1,
+      sym_plain_value,
+    STATE(164), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -9935,7 +10258,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [6357] = 13,
+  [6204] = 13,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -9954,13 +10277,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
     ACTIONS(267), 1,
       anon_sym_DQUOTE,
-    ACTIONS(614), 1,
+    ACTIONS(636), 1,
       sym_identifier,
-    ACTIONS(762), 1,
+    ACTIONS(776), 1,
       sym_important,
-    ACTIONS(764), 1,
+    ACTIONS(778), 1,
       sym_plain_value,
-    STATE(262), 9,
+    STATE(274), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -9970,7 +10293,322 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [6405] = 13,
+  [6252] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(736), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(738), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6280] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(732), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(734), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6308] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(225), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(227), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(257), 1,
+      anon_sym_POUND,
+    ACTIONS(259), 1,
+      anon_sym_LBRACK,
+    ACTIONS(265), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(267), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(636), 1,
+      sym_identifier,
+    ACTIONS(780), 1,
+      sym_important,
+    ACTIONS(782), 1,
+      sym_plain_value,
+    STATE(260), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [6356] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(225), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(227), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(257), 1,
+      anon_sym_POUND,
+    ACTIONS(259), 1,
+      anon_sym_LBRACK,
+    ACTIONS(265), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(267), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(636), 1,
+      sym_identifier,
+    ACTIONS(784), 1,
+      sym_important,
+    ACTIONS(786), 1,
+      sym_plain_value,
+    STATE(270), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [6404] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(740), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(742), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6432] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(744), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(746), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6460] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(748), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(750), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6488] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(716), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(718), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6516] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(720), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(722), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6544] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(668), 1,
+      anon_sym_POUND,
+    ACTIONS(670), 1,
+      anon_sym_LBRACK,
+    ACTIONS(674), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(676), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(678), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(680), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(682), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(684), 1,
+      sym_identifier,
+    ACTIONS(788), 1,
+      sym_important,
+    ACTIONS(790), 1,
+      sym_plain_value,
+    STATE(190), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [6592] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(225), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(227), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(257), 1,
+      anon_sym_POUND,
+    ACTIONS(259), 1,
+      anon_sym_LBRACK,
+    ACTIONS(265), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(267), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(636), 1,
+      sym_identifier,
+    ACTIONS(792), 1,
+      sym_important,
+    ACTIONS(794), 1,
+      sym_plain_value,
+    STATE(268), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [6640] = 13,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -9993,9 +10631,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
     ACTIONS(267), 1,
       anon_sym_DQUOTE,
-    ACTIONS(614), 1,
+    ACTIONS(636), 1,
       sym_identifier,
-    STATE(239), 9,
+    STATE(254), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -10005,182 +10643,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [6453] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(225), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(227), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(257), 1,
-      anon_sym_POUND,
-    ACTIONS(259), 1,
-      anon_sym_LBRACK,
-    ACTIONS(261), 1,
-      sym_important,
-    ACTIONS(265), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(267), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(271), 1,
-      sym_plain_value,
-    ACTIONS(614), 1,
-      sym_identifier,
-    STATE(266), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [6501] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(191), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(197), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(199), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(243), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      anon_sym_LBRACK,
-    ACTIONS(251), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(253), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(289), 1,
-      sym_identifier,
-    ACTIONS(766), 1,
-      sym_important,
-    ACTIONS(768), 1,
-      sym_plain_value,
-    STATE(21), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [6549] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(225), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(227), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(257), 1,
-      anon_sym_POUND,
-    ACTIONS(259), 1,
-      anon_sym_LBRACK,
-    ACTIONS(265), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(267), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(614), 1,
-      sym_identifier,
-    ACTIONS(770), 1,
-      sym_important,
-    ACTIONS(772), 1,
-      sym_plain_value,
-    STATE(274), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [6597] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(225), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(227), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(257), 1,
-      anon_sym_POUND,
-    ACTIONS(259), 1,
-      anon_sym_LBRACK,
-    ACTIONS(265), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(267), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(614), 1,
-      sym_identifier,
-    ACTIONS(774), 1,
-      sym_important,
-    ACTIONS(776), 1,
-      sym_plain_value,
-    STATE(264), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [6645] = 13,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(219), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(225), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(227), 1,
-      aux_sym_float_value_token1,
-    ACTIONS(233), 1,
-      sym_important,
-    ACTIONS(235), 1,
-      sym_plain_value,
-    ACTIONS(257), 1,
-      anon_sym_POUND,
-    ACTIONS(259), 1,
-      anon_sym_LBRACK,
-    ACTIONS(265), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(267), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(614), 1,
-      sym_identifier,
-    STATE(245), 9,
-      sym__value,
-      sym_parenthesized_value,
-      sym_color_value,
-      sym_string_value,
-      sym_integer_value,
-      sym_float_value,
-      sym_grid_value,
-      sym_call_expression,
-      sym_binary_expression,
-  [6693] = 13,
+  [6688] = 13,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -10203,9 +10666,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_important,
     ACTIONS(275), 1,
       sym_plain_value,
-    ACTIONS(614), 1,
+    ACTIONS(636), 1,
       sym_identifier,
-    STATE(269), 9,
+    STATE(271), 9,
       sym__value,
       sym_parenthesized_value,
       sym_color_value,
@@ -10215,11 +10678,46 @@ static const uint16_t ts_small_parse_table[] = {
       sym_grid_value,
       sym_call_expression,
       sym_binary_expression,
-  [6741] = 3,
+  [6736] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(191), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(197), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(199), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(243), 1,
+      anon_sym_POUND,
+    ACTIONS(245), 1,
+      anon_sym_LBRACK,
+    ACTIONS(251), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(253), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(289), 1,
+      sym_identifier,
+    ACTIONS(796), 1,
+      sym_important,
+    ACTIONS(798), 1,
+      sym_plain_value,
+    STATE(20), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [6784] = 3,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(644), 8,
+    ACTIONS(724), 8,
       anon_sym_ATimport,
       anon_sym_ATmedia,
       anon_sym_ATcharset,
@@ -10228,7 +10726,127 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keyframes_statement_token1,
       anon_sym_ATsupports,
       sym_at_keyword,
-    ACTIONS(642), 11,
+    ACTIONS(726), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6812] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(728), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(730), 11,
+      sym__pseudo_class_selector_colon,
+      ts_builtin_sym_end,
+      sym_nesting_selector,
+      anon_sym_STAR,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+      sym_identifier,
+  [6840] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(225), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(227), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(233), 1,
+      sym_important,
+    ACTIONS(235), 1,
+      sym_plain_value,
+    ACTIONS(257), 1,
+      anon_sym_POUND,
+    ACTIONS(259), 1,
+      anon_sym_LBRACK,
+    ACTIONS(265), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(267), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(636), 1,
+      sym_identifier,
+    STATE(256), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [6888] = 13,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(219), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(225), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(227), 1,
+      aux_sym_float_value_token1,
+    ACTIONS(257), 1,
+      anon_sym_POUND,
+    ACTIONS(259), 1,
+      anon_sym_LBRACK,
+    ACTIONS(261), 1,
+      sym_important,
+    ACTIONS(265), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(267), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(271), 1,
+      sym_plain_value,
+    ACTIONS(636), 1,
+      sym_identifier,
+    STATE(275), 9,
+      sym__value,
+      sym_parenthesized_value,
+      sym_color_value,
+      sym_string_value,
+      sym_integer_value,
+      sym_float_value,
+      sym_grid_value,
+      sym_call_expression,
+      sym_binary_expression,
+  [6936] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(628), 8,
+      anon_sym_ATimport,
+      anon_sym_ATmedia,
+      anon_sym_ATcharset,
+      anon_sym_ATnamespace,
+      anon_sym_ATkeyframes,
+      aux_sym_keyframes_statement_token1,
+      anon_sym_ATsupports,
+      sym_at_keyword,
+    ACTIONS(626), 11,
       sym__pseudo_class_selector_colon,
       anon_sym_RBRACE,
       sym_nesting_selector,
@@ -10240,12 +10858,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
       sym_identifier,
-  [6769] = 4,
+  [6964] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(780), 7,
+    ACTIONS(802), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10253,7 +10871,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(778), 11,
+    ACTIONS(800), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10265,12 +10883,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [6798] = 4,
+  [6993] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(784), 7,
+    ACTIONS(806), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10278,7 +10896,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(782), 11,
+    ACTIONS(804), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10290,12 +10908,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [6827] = 4,
+  [7022] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(788), 7,
+    ACTIONS(810), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10303,7 +10921,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(786), 11,
+    ACTIONS(808), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10315,12 +10933,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [6856] = 4,
+  [7051] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(792), 7,
+    ACTIONS(814), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10328,7 +10946,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(790), 11,
+    ACTIONS(812), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10340,12 +10958,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [6885] = 4,
+  [7080] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(796), 7,
+    ACTIONS(422), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10353,7 +10971,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(794), 11,
+    ACTIONS(420), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10365,12 +10983,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [6914] = 4,
+  [7109] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(800), 7,
+    ACTIONS(818), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10378,7 +10996,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(798), 11,
+    ACTIONS(816), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10390,12 +11008,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [6943] = 4,
+  [7138] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(804), 7,
+    ACTIONS(822), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10403,7 +11021,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(802), 11,
+    ACTIONS(820), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10415,12 +11033,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [6972] = 4,
+  [7167] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(808), 7,
+    ACTIONS(826), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10428,7 +11046,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(806), 11,
+    ACTIONS(824), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10440,12 +11058,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7001] = 4,
+  [7196] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(812), 7,
+    ACTIONS(830), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10453,7 +11071,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(810), 11,
+    ACTIONS(828), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10465,12 +11083,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7030] = 4,
+  [7225] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(816), 7,
+    ACTIONS(834), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10478,7 +11096,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(814), 11,
+    ACTIONS(832), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10490,12 +11108,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7059] = 4,
+  [7254] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(820), 7,
+    ACTIONS(838), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10503,7 +11121,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(818), 11,
+    ACTIONS(836), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10515,12 +11133,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7088] = 4,
+  [7283] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(418), 7,
+    ACTIONS(842), 7,
       anon_sym_PLUS,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
@@ -10528,7 +11146,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(416), 11,
+    ACTIONS(840), 11,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10540,91 +11158,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7117] = 6,
+  [7312] = 6,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(283), 1,
-      anon_sym_STAR,
-    ACTIONS(285), 3,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-    ACTIONS(824), 4,
-      aux_sym_integer_value_token1,
-      aux_sym_float_value_token1,
-      sym_identifier,
-      sym_plain_value,
-    ACTIONS(822), 9,
-      anon_sym_COMMA,
+    ACTIONS(844), 1,
       anon_sym_SEMI,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_RPAREN,
-      sym_important,
-      anon_sym_LPAREN2,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-  [7149] = 6,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(283), 1,
-      anon_sym_STAR,
-    ACTIONS(285), 3,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-    ACTIONS(826), 4,
-      aux_sym_integer_value_token1,
-      aux_sym_float_value_token1,
-      sym_identifier,
-      sym_plain_value,
-    ACTIONS(374), 9,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_RBRACE,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      sym_important,
-      anon_sym_LPAREN2,
-      anon_sym_SQUOTE,
-      anon_sym_DQUOTE,
-  [7181] = 5,
-    ACTIONS(365), 1,
-      anon_sym_RBRACK,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(303), 2,
-      anon_sym_TILDE,
-      anon_sym_PIPE,
-    ACTIONS(363), 6,
-      anon_sym_EQ,
-      anon_sym_TILDE_EQ,
-      anon_sym_CARET_EQ,
-      anon_sym_PIPE_EQ,
-      anon_sym_STAR_EQ,
-      anon_sym_DOLLAR_EQ,
-    ACTIONS(299), 8,
-      sym__descendant_operator,
-      sym__pseudo_class_selector_colon,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_GT,
-      anon_sym_PLUS,
-  [7211] = 6,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(828), 1,
-      anon_sym_SEMI,
-    ACTIONS(830), 1,
+    ACTIONS(846), 1,
       anon_sym_RBRACE,
     ACTIONS(430), 7,
       anon_sym_PLUS,
@@ -10643,8 +11184,34 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7243] = 5,
-    ACTIONS(365), 1,
+  [7344] = 6,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(283), 1,
+      anon_sym_STAR,
+    ACTIONS(285), 3,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+    ACTIONS(850), 4,
+      aux_sym_integer_value_token1,
+      aux_sym_float_value_token1,
+      sym_identifier,
+      sym_plain_value,
+    ACTIONS(848), 9,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_RBRACE,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      sym_important,
+      anon_sym_LPAREN2,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+  [7376] = 5,
+    ACTIONS(371), 1,
       anon_sym_RBRACK,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -10652,7 +11219,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(428), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(363), 6,
+    ACTIONS(369), 6,
       anon_sym_EQ,
       anon_sym_TILDE_EQ,
       anon_sym_CARET_EQ,
@@ -10668,7 +11235,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
       anon_sym_GT,
       anon_sym_PLUS,
-  [7273] = 6,
+  [7406] = 6,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -10679,12 +11246,38 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PLUS,
       anon_sym_DASH,
       anon_sym_SLASH,
-    ACTIONS(834), 4,
+    ACTIONS(854), 4,
       aux_sym_integer_value_token1,
       aux_sym_float_value_token1,
       sym_identifier,
       sym_plain_value,
-    ACTIONS(832), 9,
+    ACTIONS(852), 9,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_RPAREN,
+      sym_important,
+      anon_sym_LPAREN2,
+      anon_sym_SQUOTE,
+      anon_sym_DQUOTE,
+  [7438] = 6,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(283), 1,
+      anon_sym_STAR,
+    ACTIONS(285), 3,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+    ACTIONS(856), 4,
+      aux_sym_integer_value_token1,
+      aux_sym_float_value_token1,
+      sym_identifier,
+      sym_plain_value,
+    ACTIONS(378), 9,
       anon_sym_COMMA,
       anon_sym_SEMI,
       anon_sym_RBRACE,
@@ -10694,8 +11287,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7305] = 5,
-    ACTIONS(838), 1,
+  [7470] = 5,
+    ACTIONS(371), 1,
       anon_sym_RBRACK,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -10703,7 +11296,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(303), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(836), 6,
+    ACTIONS(369), 6,
       anon_sym_EQ,
       anon_sym_TILDE_EQ,
       anon_sym_CARET_EQ,
@@ -10719,8 +11312,33 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
       anon_sym_GT,
       anon_sym_PLUS,
-  [7335] = 5,
-    ACTIONS(838), 1,
+  [7500] = 5,
+    ACTIONS(860), 1,
+      anon_sym_RBRACK,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(303), 2,
+      anon_sym_TILDE,
+      anon_sym_PIPE,
+    ACTIONS(858), 6,
+      anon_sym_EQ,
+      anon_sym_TILDE_EQ,
+      anon_sym_CARET_EQ,
+      anon_sym_PIPE_EQ,
+      anon_sym_STAR_EQ,
+      anon_sym_DOLLAR_EQ,
+    ACTIONS(299), 8,
+      sym__descendant_operator,
+      sym__pseudo_class_selector_colon,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_GT,
+      anon_sym_PLUS,
+  [7530] = 5,
+    ACTIONS(860), 1,
       anon_sym_RBRACK,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -10728,7 +11346,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(428), 2,
       anon_sym_TILDE,
       anon_sym_PIPE,
-    ACTIONS(836), 6,
+    ACTIONS(858), 6,
       anon_sym_EQ,
       anon_sym_TILDE_EQ,
       anon_sym_CARET_EQ,
@@ -10744,14 +11362,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACK,
       anon_sym_GT,
       anon_sym_PLUS,
-  [7365] = 6,
+  [7560] = 6,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(414), 1,
       anon_sym_SEMI,
-    ACTIONS(412), 1,
+    ACTIONS(416), 1,
       anon_sym_RBRACE,
     ACTIONS(430), 7,
       anon_sym_PLUS,
@@ -10770,12 +11388,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7397] = 5,
+  [7592] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(828), 1,
+    ACTIONS(414), 1,
       anon_sym_SEMI,
     ACTIONS(430), 7,
       anon_sym_PLUS,
@@ -10794,12 +11412,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7426] = 5,
+  [7621] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(844), 1,
       anon_sym_SEMI,
     ACTIONS(430), 7,
       anon_sym_PLUS,
@@ -10818,12 +11436,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7455] = 5,
+  [7650] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(840), 1,
+    ACTIONS(862), 1,
       anon_sym_SEMI,
     ACTIONS(430), 7,
       anon_sym_PLUS,
@@ -10842,70 +11460,41 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7484] = 10,
+  [7679] = 10,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
     ACTIONS(249), 1,
       anon_sym_selector,
-    ACTIONS(842), 1,
+    ACTIONS(864), 1,
       anon_sym_SEMI,
-    ACTIONS(846), 1,
+    ACTIONS(868), 1,
       anon_sym_LPAREN2,
-    ACTIONS(850), 1,
+    ACTIONS(872), 1,
       sym_identifier,
     ACTIONS(241), 2,
       anon_sym_not,
       anon_sym_only,
-    ACTIONS(844), 2,
+    ACTIONS(866), 2,
       anon_sym_STAR,
       anon_sym_PLUS,
-    ACTIONS(848), 2,
+    ACTIONS(870), 2,
       anon_sym_DASH,
       anon_sym_SLASH,
-    STATE(263), 6,
+    STATE(272), 6,
       sym__query,
       sym_feature_query,
       sym_parenthesized_query,
       sym_binary_query,
       sym_unary_query,
       sym_selector_query,
-  [7523] = 10,
+  [7718] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(249), 1,
-      anon_sym_selector,
-    ACTIONS(846), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(850), 1,
-      sym_identifier,
-    ACTIONS(852), 1,
-      anon_sym_SEMI,
-    ACTIONS(241), 2,
-      anon_sym_not,
-      anon_sym_only,
-    ACTIONS(844), 2,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-    ACTIONS(848), 2,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-    STATE(267), 6,
-      sym__query,
-      sym_feature_query,
-      sym_parenthesized_query,
-      sym_binary_query,
-      sym_unary_query,
-      sym_selector_query,
-  [7562] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(446), 1,
+    ACTIONS(448), 1,
       anon_sym_SEMI,
     ACTIONS(430), 7,
       anon_sym_PLUS,
@@ -10924,7 +11513,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN2,
       anon_sym_SQUOTE,
       anon_sym_DQUOTE,
-  [7591] = 5,
+  [7747] = 10,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(249), 1,
+      anon_sym_selector,
+    ACTIONS(868), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(872), 1,
+      sym_identifier,
+    ACTIONS(874), 1,
+      anon_sym_SEMI,
+    ACTIONS(241), 2,
+      anon_sym_not,
+      anon_sym_only,
+    ACTIONS(866), 2,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+    ACTIONS(870), 2,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+    STATE(273), 6,
+      sym__query,
+      sym_feature_query,
+      sym_parenthesized_query,
+      sym_binary_query,
+      sym_unary_query,
+      sym_selector_query,
+  [7786] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
@@ -10947,14 +11565,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_PLUS,
       anon_sym_PIPE,
-  [7619] = 4,
+  [7814] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(418), 1,
+    ACTIONS(422), 1,
       anon_sym_SLASH,
-    ACTIONS(416), 14,
+    ACTIONS(420), 14,
       sym__descendant_operator,
       sym__pseudo_class_selector_colon,
       anon_sym_COMMA,
@@ -10969,18 +11587,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PLUS,
       anon_sym_PIPE,
       anon_sym_DASH,
-  [7645] = 9,
+  [7840] = 9,
     ACTIONS(249), 1,
       anon_sym_selector,
-    ACTIONS(846), 1,
+    ACTIONS(868), 1,
       anon_sym_LPAREN2,
-    ACTIONS(850), 1,
+    ACTIONS(872), 1,
       sym_identifier,
-    ACTIONS(854), 1,
+    ACTIONS(876), 1,
       anon_sym_SEMI,
-    ACTIONS(856), 1,
+    ACTIONS(878), 1,
       anon_sym_LBRACE,
-    STATE(96), 1,
+    STATE(136), 1,
       sym_block,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -10988,15 +11606,15 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(241), 2,
       anon_sym_not,
       anon_sym_only,
-    STATE(246), 6,
+    STATE(249), 6,
       sym__query,
       sym_feature_query,
       sym_parenthesized_query,
       sym_binary_query,
       sym_unary_query,
       sym_selector_query,
-  [7680] = 3,
-    ACTIONS(858), 1,
+  [7875] = 3,
+    ACTIONS(880), 1,
       anon_sym_COLON,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -11014,145 +11632,126 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_PLUS,
       anon_sym_PIPE,
-  [7702] = 3,
-    ACTIONS(860), 1,
-      anon_sym_COLON,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(299), 12,
-      sym__descendant_operator,
-      sym__pseudo_class_selector_colon,
+  [7897] = 14,
+    ACTIONS(490), 1,
+      anon_sym_DOT,
+    ACTIONS(882), 1,
       anon_sym_COMMA,
+    ACTIONS(884), 1,
       anon_sym_LBRACE,
-      anon_sym_DOT,
-      anon_sym_COLON_COLON,
-      anon_sym_POUND,
-      anon_sym_LBRACK,
-      anon_sym_GT,
-      anon_sym_TILDE,
-      anon_sym_PLUS,
-      anon_sym_PIPE,
-  [7724] = 14,
-    ACTIONS(564), 1,
-      anon_sym_DOT,
-    ACTIONS(862), 1,
-      anon_sym_COMMA,
-    ACTIONS(864), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(866), 1,
-      anon_sym_POUND,
-    ACTIONS(868), 1,
-      anon_sym_LBRACK,
-    ACTIONS(870), 1,
-      anon_sym_GT,
-    ACTIONS(872), 1,
-      anon_sym_TILDE,
-    ACTIONS(874), 1,
-      anon_sym_PLUS,
-    ACTIONS(876), 1,
-      anon_sym_PIPE,
-    ACTIONS(878), 1,
-      anon_sym_RPAREN,
-    ACTIONS(880), 1,
-      sym__descendant_operator,
-    ACTIONS(882), 1,
-      sym__pseudo_class_selector_colon,
-    STATE(301), 1,
-      aux_sym_selectors_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [7768] = 12,
-    ACTIONS(564), 1,
-      anon_sym_DOT,
-    ACTIONS(864), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(866), 1,
-      anon_sym_POUND,
-    ACTIONS(868), 1,
-      anon_sym_LBRACK,
-    ACTIONS(870), 1,
-      anon_sym_GT,
-    ACTIONS(872), 1,
-      anon_sym_TILDE,
-    ACTIONS(874), 1,
-      anon_sym_PLUS,
-    ACTIONS(876), 1,
-      anon_sym_PIPE,
-    ACTIONS(880), 1,
-      sym__descendant_operator,
-    ACTIONS(882), 1,
-      sym__pseudo_class_selector_colon,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(884), 3,
-      anon_sym_COMMA,
-      anon_sym_LBRACE,
-      anon_sym_RPAREN,
-  [7808] = 14,
-    ACTIONS(564), 1,
-      anon_sym_DOT,
-    ACTIONS(862), 1,
-      anon_sym_COMMA,
-    ACTIONS(864), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(866), 1,
-      anon_sym_POUND,
-    ACTIONS(868), 1,
-      anon_sym_LBRACK,
-    ACTIONS(870), 1,
-      anon_sym_GT,
-    ACTIONS(872), 1,
-      anon_sym_TILDE,
-    ACTIONS(874), 1,
-      anon_sym_PLUS,
-    ACTIONS(876), 1,
-      anon_sym_PIPE,
-    ACTIONS(880), 1,
-      sym__descendant_operator,
-    ACTIONS(882), 1,
-      sym__pseudo_class_selector_colon,
     ACTIONS(886), 1,
-      anon_sym_LBRACE,
-    STATE(292), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(888), 1,
+      anon_sym_POUND,
+    ACTIONS(890), 1,
+      anon_sym_LBRACK,
+    ACTIONS(892), 1,
+      anon_sym_GT,
+    ACTIONS(894), 1,
+      anon_sym_TILDE,
+    ACTIONS(896), 1,
+      anon_sym_PLUS,
+    ACTIONS(898), 1,
+      anon_sym_PIPE,
+    ACTIONS(900), 1,
+      sym__descendant_operator,
+    ACTIONS(902), 1,
+      sym__pseudo_class_selector_colon,
+    STATE(306), 1,
       aux_sym_selectors_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [7852] = 14,
-    ACTIONS(420), 1,
-      anon_sym_COMMA,
-    ACTIONS(436), 1,
-      anon_sym_RPAREN,
-    ACTIONS(564), 1,
+  [7941] = 14,
+    ACTIONS(490), 1,
       anon_sym_DOT,
-    ACTIONS(864), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(866), 1,
-      anon_sym_POUND,
-    ACTIONS(868), 1,
-      anon_sym_LBRACK,
-    ACTIONS(870), 1,
-      anon_sym_GT,
-    ACTIONS(872), 1,
-      anon_sym_TILDE,
-    ACTIONS(874), 1,
-      anon_sym_PLUS,
-    ACTIONS(876), 1,
-      anon_sym_PIPE,
-    ACTIONS(880), 1,
-      sym__descendant_operator,
     ACTIONS(882), 1,
+      anon_sym_COMMA,
+    ACTIONS(886), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(888), 1,
+      anon_sym_POUND,
+    ACTIONS(890), 1,
+      anon_sym_LBRACK,
+    ACTIONS(892), 1,
+      anon_sym_GT,
+    ACTIONS(894), 1,
+      anon_sym_TILDE,
+    ACTIONS(896), 1,
+      anon_sym_PLUS,
+    ACTIONS(898), 1,
+      anon_sym_PIPE,
+    ACTIONS(900), 1,
+      sym__descendant_operator,
+    ACTIONS(902), 1,
       sym__pseudo_class_selector_colon,
-    STATE(299), 1,
+    ACTIONS(904), 1,
+      anon_sym_RPAREN,
+    STATE(309), 1,
+      aux_sym_selectors_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [7985] = 12,
+    ACTIONS(490), 1,
+      anon_sym_DOT,
+    ACTIONS(886), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(888), 1,
+      anon_sym_POUND,
+    ACTIONS(890), 1,
+      anon_sym_LBRACK,
+    ACTIONS(892), 1,
+      anon_sym_GT,
+    ACTIONS(894), 1,
+      anon_sym_TILDE,
+    ACTIONS(896), 1,
+      anon_sym_PLUS,
+    ACTIONS(898), 1,
+      anon_sym_PIPE,
+    ACTIONS(900), 1,
+      sym__descendant_operator,
+    ACTIONS(902), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(906), 3,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_RPAREN,
+  [8025] = 14,
+    ACTIONS(357), 1,
+      anon_sym_COMMA,
+    ACTIONS(410), 1,
+      anon_sym_RPAREN,
+    ACTIONS(490), 1,
+      anon_sym_DOT,
+    ACTIONS(886), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(888), 1,
+      anon_sym_POUND,
+    ACTIONS(890), 1,
+      anon_sym_LBRACK,
+    ACTIONS(892), 1,
+      anon_sym_GT,
+    ACTIONS(894), 1,
+      anon_sym_TILDE,
+    ACTIONS(896), 1,
+      anon_sym_PLUS,
+    ACTIONS(898), 1,
+      anon_sym_PIPE,
+    ACTIONS(900), 1,
+      sym__descendant_operator,
+    ACTIONS(902), 1,
+      sym__pseudo_class_selector_colon,
+    STATE(310), 1,
       aux_sym_pseudo_class_arguments_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [7896] = 3,
-    ACTIONS(888), 1,
+  [8069] = 3,
+    ACTIONS(908), 1,
       anon_sym_COLON,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -11170,71 +11769,90 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_TILDE,
       anon_sym_PLUS,
       anon_sym_PIPE,
-  [7918] = 14,
-    ACTIONS(420), 1,
-      anon_sym_COMMA,
-    ACTIONS(422), 1,
-      anon_sym_RPAREN,
-    ACTIONS(564), 1,
-      anon_sym_DOT,
-    ACTIONS(864), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(866), 1,
-      anon_sym_POUND,
-    ACTIONS(868), 1,
-      anon_sym_LBRACK,
-    ACTIONS(870), 1,
-      anon_sym_GT,
-    ACTIONS(872), 1,
-      anon_sym_TILDE,
-    ACTIONS(874), 1,
-      anon_sym_PLUS,
-    ACTIONS(876), 1,
-      anon_sym_PIPE,
-    ACTIONS(880), 1,
+  [8091] = 3,
+    ACTIONS(910), 1,
+      anon_sym_COLON,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(299), 12,
       sym__descendant_operator,
-    ACTIONS(882), 1,
       sym__pseudo_class_selector_colon,
-    STATE(290), 1,
+      anon_sym_COMMA,
+      anon_sym_LBRACE,
+      anon_sym_DOT,
+      anon_sym_COLON_COLON,
+      anon_sym_POUND,
+      anon_sym_LBRACK,
+      anon_sym_GT,
+      anon_sym_TILDE,
+      anon_sym_PLUS,
+      anon_sym_PIPE,
+  [8113] = 14,
+    ACTIONS(357), 1,
+      anon_sym_COMMA,
+    ACTIONS(359), 1,
+      anon_sym_RPAREN,
+    ACTIONS(490), 1,
+      anon_sym_DOT,
+    ACTIONS(886), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(888), 1,
+      anon_sym_POUND,
+    ACTIONS(890), 1,
+      anon_sym_LBRACK,
+    ACTIONS(892), 1,
+      anon_sym_GT,
+    ACTIONS(894), 1,
+      anon_sym_TILDE,
+    ACTIONS(896), 1,
+      anon_sym_PLUS,
+    ACTIONS(898), 1,
+      anon_sym_PIPE,
+    ACTIONS(900), 1,
+      sym__descendant_operator,
+    ACTIONS(902), 1,
+      sym__pseudo_class_selector_colon,
+    STATE(298), 1,
       aux_sym_pseudo_class_arguments_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [7962] = 12,
-    ACTIONS(564), 1,
+  [8157] = 12,
+    ACTIONS(490), 1,
       anon_sym_DOT,
-    ACTIONS(864), 1,
+    ACTIONS(886), 1,
       anon_sym_COLON_COLON,
-    ACTIONS(866), 1,
+    ACTIONS(888), 1,
       anon_sym_POUND,
-    ACTIONS(868), 1,
+    ACTIONS(890), 1,
       anon_sym_LBRACK,
-    ACTIONS(870), 1,
+    ACTIONS(892), 1,
       anon_sym_GT,
-    ACTIONS(872), 1,
+    ACTIONS(894), 1,
       anon_sym_TILDE,
-    ACTIONS(874), 1,
+    ACTIONS(896), 1,
       anon_sym_PLUS,
-    ACTIONS(876), 1,
+    ACTIONS(898), 1,
       anon_sym_PIPE,
-    ACTIONS(880), 1,
+    ACTIONS(900), 1,
       sym__descendant_operator,
-    ACTIONS(882), 1,
+    ACTIONS(902), 1,
       sym__pseudo_class_selector_colon,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(450), 2,
+    ACTIONS(462), 2,
       anon_sym_COMMA,
       anon_sym_RPAREN,
-  [8001] = 6,
+  [8196] = 6,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(890), 1,
+    ACTIONS(912), 1,
       anon_sym_LPAREN,
-    STATE(219), 1,
+    STATE(223), 1,
       sym_arguments,
     ACTIONS(301), 3,
       anon_sym_SEMI,
@@ -11248,136 +11866,38 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH,
       anon_sym_SLASH,
       sym_identifier,
-  [8028] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(892), 1,
-      sym_unit,
-    ACTIONS(734), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(736), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8052] = 6,
-    ACTIONS(249), 1,
-      anon_sym_selector,
-    ACTIONS(846), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(850), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(241), 2,
-      anon_sym_not,
-      anon_sym_only,
-    STATE(279), 6,
-      sym__query,
-      sym_feature_query,
-      sym_parenthesized_query,
-      sym_binary_query,
-      sym_unary_query,
-      sym_selector_query,
-  [8078] = 6,
-    ACTIONS(249), 1,
-      anon_sym_selector,
-    ACTIONS(846), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(850), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(241), 2,
-      anon_sym_not,
-      anon_sym_only,
-    STATE(258), 6,
-      sym__query,
-      sym_feature_query,
-      sym_parenthesized_query,
-      sym_binary_query,
-      sym_unary_query,
-      sym_selector_query,
-  [8104] = 6,
-    ACTIONS(249), 1,
-      anon_sym_selector,
-    ACTIONS(846), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(850), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(241), 2,
-      anon_sym_not,
-      anon_sym_only,
-    STATE(289), 6,
-      sym__query,
-      sym_feature_query,
-      sym_parenthesized_query,
-      sym_binary_query,
-      sym_unary_query,
-      sym_selector_query,
-  [8130] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(894), 1,
-      sym_unit,
-    ACTIONS(740), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(742), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8154] = 12,
-    ACTIONS(564), 1,
+  [8223] = 12,
+    ACTIONS(490), 1,
       anon_sym_DOT,
-    ACTIONS(864), 1,
+    ACTIONS(886), 1,
       anon_sym_COLON_COLON,
-    ACTIONS(866), 1,
+    ACTIONS(888), 1,
       anon_sym_POUND,
-    ACTIONS(868), 1,
+    ACTIONS(890), 1,
       anon_sym_LBRACK,
-    ACTIONS(870), 1,
+    ACTIONS(892), 1,
       anon_sym_GT,
-    ACTIONS(872), 1,
+    ACTIONS(894), 1,
       anon_sym_TILDE,
-    ACTIONS(874), 1,
-      anon_sym_PLUS,
-    ACTIONS(876), 1,
-      anon_sym_PIPE,
-    ACTIONS(880), 1,
-      sym__descendant_operator,
-    ACTIONS(882), 1,
-      sym__pseudo_class_selector_colon,
     ACTIONS(896), 1,
+      anon_sym_PLUS,
+    ACTIONS(898), 1,
+      anon_sym_PIPE,
+    ACTIONS(900), 1,
+      sym__descendant_operator,
+    ACTIONS(902), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(914), 1,
       anon_sym_RPAREN,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [8192] = 6,
+  [8261] = 6,
     ACTIONS(249), 1,
       anon_sym_selector,
-    ACTIONS(846), 1,
+    ACTIONS(868), 1,
       anon_sym_LPAREN2,
-    ACTIONS(850), 1,
+    ACTIONS(872), 1,
       sym_identifier,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -11385,37 +11905,121 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(241), 2,
       anon_sym_not,
       anon_sym_only,
-    STATE(254), 6,
+    STATE(295), 6,
       sym__query,
       sym_feature_query,
       sym_parenthesized_query,
       sym_binary_query,
       sym_unary_query,
       sym_selector_query,
-  [8218] = 4,
+  [8287] = 6,
+    ACTIONS(249), 1,
+      anon_sym_selector,
+    ACTIONS(868), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(872), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(241), 2,
+      anon_sym_not,
+      anon_sym_only,
+    STATE(259), 6,
+      sym__query,
+      sym_feature_query,
+      sym_parenthesized_query,
+      sym_binary_query,
+      sym_unary_query,
+      sym_selector_query,
+  [8313] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(782), 5,
+    ACTIONS(916), 1,
+      sym_unit,
+    ACTIONS(760), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(762), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8337] = 5,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(918), 1,
+      sym_unit,
+    ACTIONS(766), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(768), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8361] = 12,
+    ACTIONS(490), 1,
+      anon_sym_DOT,
+    ACTIONS(886), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(888), 1,
+      anon_sym_POUND,
+    ACTIONS(890), 1,
+      anon_sym_LBRACK,
+    ACTIONS(892), 1,
+      anon_sym_GT,
+    ACTIONS(894), 1,
+      anon_sym_TILDE,
+    ACTIONS(896), 1,
+      anon_sym_PLUS,
+    ACTIONS(898), 1,
+      anon_sym_PIPE,
+    ACTIONS(900), 1,
+      sym__descendant_operator,
+    ACTIONS(902), 1,
+      sym__pseudo_class_selector_colon,
+    ACTIONS(920), 1,
+      anon_sym_RPAREN,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [8399] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(816), 5,
       anon_sym_SEMI,
       anon_sym_LBRACE,
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_LPAREN2,
-    ACTIONS(784), 6,
+    ACTIONS(818), 6,
       anon_sym_not,
       anon_sym_only,
       anon_sym_selector,
       anon_sym_DASH,
       anon_sym_SLASH,
       sym_identifier,
-  [8240] = 6,
+  [8421] = 6,
     ACTIONS(249), 1,
       anon_sym_selector,
-    ACTIONS(846), 1,
+    ACTIONS(868), 1,
       anon_sym_LPAREN2,
-    ACTIONS(898), 1,
+    ACTIONS(872), 1,
       sym_identifier,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -11423,19 +12027,59 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(241), 2,
       anon_sym_not,
       anon_sym_only,
-    STATE(293), 6,
+    STATE(263), 6,
       sym__query,
       sym_feature_query,
       sym_parenthesized_query,
       sym_binary_query,
       sym_unary_query,
       sym_selector_query,
-  [8266] = 6,
+  [8447] = 6,
     ACTIONS(249), 1,
       anon_sym_selector,
-    ACTIONS(846), 1,
+    ACTIONS(868), 1,
       anon_sym_LPAREN2,
-    ACTIONS(850), 1,
+    ACTIONS(922), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(241), 2,
+      anon_sym_not,
+      anon_sym_only,
+    STATE(304), 6,
+      sym__query,
+      sym_feature_query,
+      sym_parenthesized_query,
+      sym_binary_query,
+      sym_unary_query,
+      sym_selector_query,
+  [8473] = 6,
+    ACTIONS(249), 1,
+      anon_sym_selector,
+    ACTIONS(868), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(872), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(241), 2,
+      anon_sym_not,
+      anon_sym_only,
+    STATE(281), 6,
+      sym__query,
+      sym_feature_query,
+      sym_parenthesized_query,
+      sym_binary_query,
+      sym_unary_query,
+      sym_selector_query,
+  [8499] = 6,
+    ACTIONS(249), 1,
+      anon_sym_selector,
+    ACTIONS(868), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(872), 1,
       sym_identifier,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -11450,271 +12094,218 @@ static const uint16_t ts_small_parse_table[] = {
       sym_binary_query,
       sym_unary_query,
       sym_selector_query,
-  [8292] = 6,
+  [8525] = 6,
     ACTIONS(249), 1,
       anon_sym_selector,
-    ACTIONS(846), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(850), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(241), 2,
-      anon_sym_not,
-      anon_sym_only,
-    STATE(250), 6,
-      sym__query,
-      sym_feature_query,
-      sym_parenthesized_query,
-      sym_binary_query,
-      sym_unary_query,
-      sym_selector_query,
-  [8318] = 6,
-    ACTIONS(249), 1,
-      anon_sym_selector,
-    ACTIONS(846), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(850), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(241), 2,
-      anon_sym_not,
-      anon_sym_only,
-    STATE(253), 6,
-      sym__query,
-      sym_feature_query,
-      sym_parenthesized_query,
-      sym_binary_query,
-      sym_unary_query,
-      sym_selector_query,
-  [8344] = 11,
-    ACTIONS(564), 1,
-      anon_sym_DOT,
-    ACTIONS(864), 1,
-      anon_sym_COLON_COLON,
-    ACTIONS(866), 1,
-      anon_sym_POUND,
     ACTIONS(868), 1,
-      anon_sym_LBRACK,
-    ACTIONS(870), 1,
-      anon_sym_GT,
+      anon_sym_LPAREN2,
     ACTIONS(872), 1,
-      anon_sym_TILDE,
-    ACTIONS(874), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(241), 2,
+      anon_sym_not,
+      anon_sym_only,
+    STATE(262), 6,
+      sym__query,
+      sym_feature_query,
+      sym_parenthesized_query,
+      sym_binary_query,
+      sym_unary_query,
+      sym_selector_query,
+  [8551] = 6,
+    ACTIONS(249), 1,
+      anon_sym_selector,
+    ACTIONS(868), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(872), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(241), 2,
+      anon_sym_not,
+      anon_sym_only,
+    STATE(286), 6,
+      sym__query,
+      sym_feature_query,
+      sym_parenthesized_query,
+      sym_binary_query,
+      sym_unary_query,
+      sym_selector_query,
+  [8577] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(840), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
       anon_sym_PLUS,
-    ACTIONS(876), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(842), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8598] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(812), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(814), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8619] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(828), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(830), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8640] = 5,
+    ACTIONS(928), 1,
+      sym_identifier,
+    STATE(89), 1,
+      sym__nth_child_pseudo_class_selector,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(926), 2,
+      anon_sym_nth_DASHchild,
+      anon_sym_nth_DASHlast_DASHchild,
+    ACTIONS(924), 6,
+      anon_sym_has,
+      anon_sym_not,
+      anon_sym_is,
+      anon_sym_where,
+      anon_sym_host,
+      anon_sym_host_DASHcontext,
+  [8663] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(420), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(422), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8684] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(820), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(822), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8705] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(824), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(826), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8726] = 11,
+    ACTIONS(490), 1,
+      anon_sym_DOT,
+    ACTIONS(886), 1,
+      anon_sym_COLON_COLON,
+    ACTIONS(888), 1,
+      anon_sym_POUND,
+    ACTIONS(890), 1,
+      anon_sym_LBRACK,
+    ACTIONS(892), 1,
+      anon_sym_GT,
+    ACTIONS(894), 1,
+      anon_sym_TILDE,
+    ACTIONS(896), 1,
+      anon_sym_PLUS,
+    ACTIONS(898), 1,
       anon_sym_PIPE,
-    ACTIONS(880), 1,
+    ACTIONS(900), 1,
       sym__descendant_operator,
-    ACTIONS(882), 1,
+    ACTIONS(902), 1,
       sym__pseudo_class_selector_colon,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [8379] = 8,
+  [8761] = 5,
+    ACTIONS(932), 1,
+      sym_identifier,
+    STATE(72), 1,
+      sym__nth_child_pseudo_class_selector,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(926), 2,
+      anon_sym_nth_DASHchild,
+      anon_sym_nth_DASHlast_DASHchild,
+    ACTIONS(930), 6,
+      anon_sym_has,
+      anon_sym_not,
+      anon_sym_is,
+      anon_sym_where,
+      anon_sym_host,
+      anon_sym_host_DASHcontext,
+  [8784] = 6,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
     ACTIONS(307), 1,
       anon_sym_SLASH,
-    ACTIONS(367), 1,
+    ACTIONS(373), 1,
       anon_sym_LPAREN,
-    ACTIONS(900), 1,
-      anon_sym_COLON,
-    STATE(227), 1,
-      sym_arguments,
-    ACTIONS(301), 3,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(470), 3,
-      anon_sym_RPAREN,
-      anon_sym_and,
-      anon_sym_or,
-  [8408] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(810), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(812), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8429] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(416), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(418), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8450] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(798), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(800), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8471] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(802), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(804), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8492] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(794), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(796), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8513] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(806), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(808), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8534] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(778), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(780), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8555] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(790), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(792), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8576] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(818), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(820), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8597] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(786), 4,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_LPAREN2,
-    ACTIONS(788), 6,
-      anon_sym_not,
-      anon_sym_only,
-      anon_sym_selector,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      sym_identifier,
-  [8618] = 6,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(307), 1,
-      anon_sym_SLASH,
-    ACTIONS(367), 1,
-      anon_sym_LPAREN,
-    STATE(227), 1,
+    STATE(237), 1,
       sym_arguments,
     ACTIONS(301), 7,
       anon_sym_COMMA,
@@ -11724,521 +12315,615 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PLUS,
       anon_sym_RPAREN,
       anon_sym_DASH,
-  [8643] = 4,
+  [8809] = 8,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(814), 4,
+    ACTIONS(307), 1,
+      anon_sym_SLASH,
+    ACTIONS(373), 1,
+      anon_sym_LPAREN,
+    ACTIONS(934), 1,
+      anon_sym_COLON,
+    STATE(237), 1,
+      sym_arguments,
+    ACTIONS(301), 3,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(470), 3,
+      anon_sym_RPAREN,
+      anon_sym_and,
+      anon_sym_or,
+  [8838] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(832), 4,
       anon_sym_SEMI,
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_LPAREN2,
-    ACTIONS(816), 6,
+    ACTIONS(834), 6,
       anon_sym_not,
       anon_sym_only,
       anon_sym_selector,
       anon_sym_DASH,
       anon_sym_SLASH,
       sym_identifier,
-  [8664] = 5,
+  [8859] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(742), 1,
-      anon_sym_SLASH,
-    ACTIONS(902), 1,
-      sym_unit,
-    ACTIONS(740), 7,
-      anon_sym_COMMA,
+    ACTIONS(836), 4,
       anon_sym_SEMI,
       anon_sym_STAR,
-      anon_sym_RBRACK,
       anon_sym_PLUS,
-      anon_sym_RPAREN,
+      anon_sym_LPAREN2,
+    ACTIONS(838), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
       anon_sym_DASH,
-  [8686] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(736), 1,
       anon_sym_SLASH,
-    ACTIONS(904), 1,
-      sym_unit,
-    ACTIONS(734), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8708] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(816), 1,
-      anon_sym_SLASH,
-    ACTIONS(814), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8727] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(792), 1,
-      anon_sym_SLASH,
-    ACTIONS(790), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8746] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(808), 1,
-      anon_sym_SLASH,
-    ACTIONS(806), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8765] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(800), 1,
-      anon_sym_SLASH,
-    ACTIONS(798), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8784] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(788), 1,
-      anon_sym_SLASH,
-    ACTIONS(786), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8803] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(780), 1,
-      anon_sym_SLASH,
-    ACTIONS(778), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8822] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(812), 1,
-      anon_sym_SLASH,
-    ACTIONS(810), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8841] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(784), 1,
-      anon_sym_SLASH,
-    ACTIONS(782), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8860] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(418), 1,
-      anon_sym_SLASH,
-    ACTIONS(416), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8879] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(804), 1,
-      anon_sym_SLASH,
-    ACTIONS(802), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8898] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(796), 1,
-      anon_sym_SLASH,
-    ACTIONS(794), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8917] = 4,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(820), 1,
-      anon_sym_SLASH,
-    ACTIONS(818), 7,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_STAR,
-      anon_sym_RBRACK,
-      anon_sym_PLUS,
-      anon_sym_RPAREN,
-      anon_sym_DASH,
-  [8936] = 6,
-    ACTIONS(906), 1,
-      anon_sym_RBRACE,
-    ACTIONS(910), 1,
-      aux_sym_integer_value_token1,
-    STATE(305), 1,
-      sym_integer_value,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(908), 2,
-      sym_from,
-      sym_to,
-    STATE(243), 2,
-      sym_keyframe_block,
-      aux_sym_keyframe_block_list_repeat1,
-  [8958] = 7,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(912), 1,
-      anon_sym_COMMA,
-    ACTIONS(916), 1,
-      anon_sym_RBRACK,
-    ACTIONS(918), 1,
-      anon_sym_SLASH,
-    STATE(295), 1,
-      aux_sym_grid_value_repeat1,
-    ACTIONS(914), 3,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [8982] = 6,
-    ACTIONS(910), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(920), 1,
-      anon_sym_RBRACE,
-    STATE(305), 1,
-      sym_integer_value,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(908), 2,
-      sym_from,
-      sym_to,
-    STATE(238), 2,
-      sym_keyframe_block,
-      aux_sym_keyframe_block_list_repeat1,
-  [9004] = 7,
-    ACTIONS(686), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(688), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(890), 1,
-      anon_sym_LPAREN,
-    ACTIONS(922), 1,
       sym_identifier,
-    STATE(219), 1,
-      sym_arguments,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    STATE(336), 2,
-      sym_string_value,
-      sym_call_expression,
-  [9028] = 6,
-    ACTIONS(910), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(924), 1,
-      anon_sym_RBRACE,
-    STATE(305), 1,
-      sym_integer_value,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(908), 2,
-      sym_from,
-      sym_to,
-    STATE(243), 2,
-      sym_keyframe_block,
-      aux_sym_keyframe_block_list_repeat1,
-  [9050] = 6,
-    ACTIONS(926), 1,
-      anon_sym_RBRACE,
-    ACTIONS(931), 1,
-      aux_sym_integer_value_token1,
-    STATE(305), 1,
-      sym_integer_value,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(928), 2,
-      sym_from,
-      sym_to,
-    STATE(243), 2,
-      sym_keyframe_block,
-      aux_sym_keyframe_block_list_repeat1,
-  [9072] = 7,
+  [8880] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(912), 1,
-      anon_sym_COMMA,
-    ACTIONS(918), 1,
-      anon_sym_SLASH,
-    ACTIONS(934), 1,
-      anon_sym_RBRACK,
-    STATE(297), 1,
-      aux_sym_grid_value_repeat1,
-    ACTIONS(914), 3,
+    ACTIONS(808), 4,
+      anon_sym_SEMI,
       anon_sym_STAR,
       anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(810), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
       anon_sym_DASH,
-  [9096] = 7,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8901] = 4,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(912), 1,
-      anon_sym_COMMA,
-    ACTIONS(918), 1,
+    ACTIONS(804), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(806), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8922] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(800), 4,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_LPAREN2,
+    ACTIONS(802), 6,
+      anon_sym_not,
+      anon_sym_only,
+      anon_sym_selector,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      sym_identifier,
+  [8943] = 5,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(762), 1,
       anon_sym_SLASH,
     ACTIONS(936), 1,
-      anon_sym_RBRACK,
-    STATE(298), 1,
-      aux_sym_grid_value_repeat1,
-    ACTIONS(914), 3,
+      sym_unit,
+    ACTIONS(760), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
       anon_sym_STAR,
+      anon_sym_RBRACK,
       anon_sym_PLUS,
+      anon_sym_RPAREN,
       anon_sym_DASH,
-  [9120] = 7,
-    ACTIONS(856), 1,
-      anon_sym_LBRACE,
-    ACTIONS(938), 1,
-      anon_sym_COMMA,
-    ACTIONS(940), 1,
-      anon_sym_SEMI,
-    STATE(141), 1,
-      sym_block,
-    STATE(271), 1,
-      aux_sym_import_statement_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(942), 2,
-      anon_sym_and,
-      anon_sym_or,
-  [9144] = 7,
-    ACTIONS(239), 1,
-      anon_sym_LBRACE,
-    ACTIONS(938), 1,
-      anon_sym_COMMA,
-    ACTIONS(944), 1,
-      anon_sym_SEMI,
-    STATE(123), 1,
-      sym_block,
-    STATE(270), 1,
-      aux_sym_import_statement_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(942), 2,
-      anon_sym_and,
-      anon_sym_or,
-  [9168] = 6,
-    ACTIONS(910), 1,
-      aux_sym_integer_value_token1,
-    ACTIONS(946), 1,
-      anon_sym_RBRACE,
-    STATE(305), 1,
-      sym_integer_value,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(908), 2,
-      sym_from,
-      sym_to,
-    STATE(242), 2,
-      sym_keyframe_block,
-      aux_sym_keyframe_block_list_repeat1,
-  [9190] = 7,
-    ACTIONS(686), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(688), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(890), 1,
-      anon_sym_LPAREN,
-    ACTIONS(922), 1,
-      sym_identifier,
-    STATE(219), 1,
-      sym_arguments,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    STATE(327), 2,
-      sym_string_value,
-      sym_call_expression,
-  [9214] = 2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(948), 6,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_LBRACE,
-      anon_sym_RPAREN,
-      anon_sym_and,
-      anon_sym_or,
-  [9227] = 2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(950), 6,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_LBRACE,
-      anon_sym_RPAREN,
-      anon_sym_and,
-      anon_sym_or,
-  [9240] = 2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(952), 6,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_LBRACE,
-      anon_sym_RPAREN,
-      anon_sym_and,
-      anon_sym_or,
-  [9253] = 6,
-    ACTIONS(239), 1,
-      anon_sym_LBRACE,
-    ACTIONS(938), 1,
-      anon_sym_COMMA,
-    STATE(90), 1,
-      sym_block,
-    STATE(283), 1,
-      aux_sym_import_statement_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(942), 2,
-      anon_sym_and,
-      anon_sym_or,
-  [9274] = 2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(954), 6,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_LBRACE,
-      anon_sym_RPAREN,
-      anon_sym_and,
-      anon_sym_or,
-  [9287] = 2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(956), 6,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_LBRACE,
-      anon_sym_RPAREN,
-      anon_sym_and,
-      anon_sym_or,
-  [9300] = 5,
+  [8965] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(918), 1,
+    ACTIONS(768), 1,
       anon_sym_SLASH,
-    ACTIONS(958), 2,
+    ACTIONS(938), 1,
+      sym_unit,
+    ACTIONS(766), 7,
       anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
       anon_sym_RBRACK,
-    ACTIONS(914), 3,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [8987] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(818), 1,
+      anon_sym_SLASH,
+    ACTIONS(816), 8,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_of,
+      anon_sym_DASH,
+  [9007] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(422), 1,
+      anon_sym_SLASH,
+    ACTIONS(420), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9026] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(826), 1,
+      anon_sym_SLASH,
+    ACTIONS(824), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9045] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(834), 1,
+      anon_sym_SLASH,
+    ACTIONS(832), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9064] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(838), 1,
+      anon_sym_SLASH,
+    ACTIONS(836), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9083] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(842), 1,
+      anon_sym_SLASH,
+    ACTIONS(840), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9102] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(802), 1,
+      anon_sym_SLASH,
+    ACTIONS(800), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9121] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(806), 1,
+      anon_sym_SLASH,
+    ACTIONS(804), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9140] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(810), 1,
+      anon_sym_SLASH,
+    ACTIONS(808), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9159] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(814), 1,
+      anon_sym_SLASH,
+    ACTIONS(812), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9178] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(822), 1,
+      anon_sym_SLASH,
+    ACTIONS(820), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9197] = 4,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(830), 1,
+      anon_sym_SLASH,
+    ACTIONS(828), 7,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_STAR,
+      anon_sym_RBRACK,
+      anon_sym_PLUS,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+  [9216] = 6,
+    ACTIONS(940), 1,
+      anon_sym_RBRACE,
+    ACTIONS(944), 1,
+      aux_sym_integer_value_token1,
+    STATE(311), 1,
+      sym_integer_value,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(942), 2,
+      sym_from,
+      sym_to,
+    STATE(252), 2,
+      sym_keyframe_block,
+      aux_sym_keyframe_block_list_repeat1,
+  [9238] = 7,
+    ACTIONS(676), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(678), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(912), 1,
+      anon_sym_LPAREN,
+    ACTIONS(946), 1,
+      sym_identifier,
+    STATE(223), 1,
+      sym_arguments,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    STATE(353), 2,
+      sym_string_value,
+      sym_call_expression,
+  [9262] = 7,
+    ACTIONS(878), 1,
+      anon_sym_LBRACE,
+    ACTIONS(948), 1,
+      anon_sym_COMMA,
+    ACTIONS(950), 1,
+      anon_sym_SEMI,
+    STATE(146), 1,
+      sym_block,
+    STATE(277), 1,
+      aux_sym_import_statement_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(952), 2,
+      anon_sym_and,
+      anon_sym_or,
+  [9286] = 7,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(954), 1,
+      anon_sym_COMMA,
+    ACTIONS(958), 1,
+      anon_sym_RBRACK,
+    ACTIONS(960), 1,
+      anon_sym_SLASH,
+    STATE(308), 1,
+      aux_sym_grid_value_repeat1,
+    ACTIONS(956), 3,
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [9319] = 2,
+  [9310] = 6,
+    ACTIONS(944), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(962), 1,
+      anon_sym_RBRACE,
+    STATE(311), 1,
+      sym_integer_value,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(942), 2,
+      sym_from,
+      sym_to,
+    STATE(252), 2,
+      sym_keyframe_block,
+      aux_sym_keyframe_block_list_repeat1,
+  [9332] = 6,
+    ACTIONS(964), 1,
+      anon_sym_RBRACE,
+    ACTIONS(969), 1,
+      aux_sym_integer_value_token1,
+    STATE(311), 1,
+      sym_integer_value,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(966), 2,
+      sym_from,
+      sym_to,
+    STATE(252), 2,
+      sym_keyframe_block,
+      aux_sym_keyframe_block_list_repeat1,
+  [9354] = 7,
+    ACTIONS(239), 1,
+      anon_sym_LBRACE,
+    ACTIONS(948), 1,
+      anon_sym_COMMA,
+    ACTIONS(972), 1,
+      anon_sym_SEMI,
+    STATE(127), 1,
+      sym_block,
+    STATE(276), 1,
+      aux_sym_import_statement_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(952), 2,
+      anon_sym_and,
+      anon_sym_or,
+  [9378] = 7,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(954), 1,
+      anon_sym_COMMA,
+    ACTIONS(960), 1,
+      anon_sym_SLASH,
+    ACTIONS(974), 1,
+      anon_sym_RBRACK,
+    STATE(303), 1,
+      aux_sym_grid_value_repeat1,
+    ACTIONS(956), 3,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [9402] = 6,
+    ACTIONS(944), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(976), 1,
+      anon_sym_RBRACE,
+    STATE(311), 1,
+      sym_integer_value,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(942), 2,
+      sym_from,
+      sym_to,
+    STATE(247), 2,
+      sym_keyframe_block,
+      aux_sym_keyframe_block_list_repeat1,
+  [9424] = 7,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(954), 1,
+      anon_sym_COMMA,
+    ACTIONS(960), 1,
+      anon_sym_SLASH,
+    ACTIONS(978), 1,
+      anon_sym_RBRACK,
+    STATE(307), 1,
+      aux_sym_grid_value_repeat1,
+    ACTIONS(956), 3,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [9448] = 7,
+    ACTIONS(676), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(678), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(912), 1,
+      anon_sym_LPAREN,
+    ACTIONS(946), 1,
+      sym_identifier,
+    STATE(223), 1,
+      sym_arguments,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    STATE(331), 2,
+      sym_string_value,
+      sym_call_expression,
+  [9472] = 6,
+    ACTIONS(944), 1,
+      aux_sym_integer_value_token1,
+    ACTIONS(980), 1,
+      anon_sym_RBRACE,
+    STATE(311), 1,
+      sym_integer_value,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(942), 2,
+      sym_from,
+      sym_to,
+    STATE(251), 2,
+      sym_keyframe_block,
+      aux_sym_keyframe_block_list_repeat1,
+  [9494] = 6,
+    ACTIONS(878), 1,
+      anon_sym_LBRACE,
+    ACTIONS(948), 1,
+      anon_sym_COMMA,
+    STATE(115), 1,
+      sym_block,
+    STATE(293), 1,
+      aux_sym_import_statement_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(952), 2,
+      anon_sym_and,
+      anon_sym_or,
+  [9515] = 5,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(960), 1,
+      anon_sym_SLASH,
+    ACTIONS(982), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+    ACTIONS(956), 3,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [9534] = 2,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(984), 6,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_LBRACE,
+      anon_sym_RPAREN,
+      anon_sym_and,
+      anon_sym_or,
+  [9547] = 6,
+    ACTIONS(239), 1,
+      anon_sym_LBRACE,
+    ACTIONS(948), 1,
+      anon_sym_COMMA,
+    STATE(121), 1,
+      sym_block,
+    STATE(287), 1,
+      aux_sym_import_statement_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(952), 2,
+      anon_sym_and,
+      anon_sym_or,
+  [9568] = 2,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(986), 6,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_LBRACE,
+      anon_sym_RPAREN,
+      anon_sym_and,
+      anon_sym_or,
+  [9581] = 2,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(988), 6,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_LBRACE,
+      anon_sym_RPAREN,
+      anon_sym_and,
+      anon_sym_or,
+  [9594] = 2,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(990), 6,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_LBRACE,
+      anon_sym_RPAREN,
+      anon_sym_and,
+      anon_sym_or,
+  [9607] = 2,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
@@ -12249,248 +12934,213 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_and,
       anon_sym_or,
-  [9332] = 6,
-    ACTIONS(856), 1,
-      anon_sym_LBRACE,
-    ACTIONS(938), 1,
-      anon_sym_COMMA,
-    STATE(142), 1,
-      sym_block,
-    STATE(275), 1,
-      aux_sym_import_statement_repeat1,
+  [9620] = 2,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(942), 2,
+    ACTIONS(992), 6,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+      anon_sym_LBRACE,
+      anon_sym_RPAREN,
       anon_sym_and,
       anon_sym_or,
-  [9353] = 3,
-    ACTIONS(962), 1,
+  [9633] = 5,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(960), 1,
+      anon_sym_SLASH,
+    ACTIONS(994), 1,
+      anon_sym_SEMI,
+    ACTIONS(956), 3,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [9651] = 5,
+    ACTIONS(676), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(678), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(996), 1,
       sym_identifier,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(960), 4,
-      anon_sym_has,
-      anon_sym_not,
-      anon_sym_is,
-      anon_sym_where,
-  [9367] = 5,
+    STATE(361), 2,
+      sym_string_value,
+      sym_call_expression,
+  [9669] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(918), 1,
+    ACTIONS(960), 1,
       anon_sym_SLASH,
-    ACTIONS(964), 1,
+    ACTIONS(998), 1,
       anon_sym_RBRACK,
-    ACTIONS(914), 3,
+    ACTIONS(956), 3,
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [9385] = 3,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(942), 2,
-      anon_sym_and,
-      anon_sym_or,
-    ACTIONS(966), 3,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-      anon_sym_LBRACE,
-  [9399] = 5,
+  [9687] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(918), 1,
+    ACTIONS(960), 1,
       anon_sym_SLASH,
-    ACTIONS(968), 1,
-      anon_sym_SEMI,
-    ACTIONS(914), 3,
+    ACTIONS(1000), 1,
+      anon_sym_RPAREN,
+    ACTIONS(956), 3,
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [9417] = 5,
-    ACTIONS(938), 1,
+  [9705] = 5,
+    ACTIONS(948), 1,
       anon_sym_COMMA,
-    ACTIONS(970), 1,
+    ACTIONS(1002), 1,
       anon_sym_SEMI,
     STATE(300), 1,
       aux_sym_import_statement_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(942), 2,
+    ACTIONS(952), 2,
       anon_sym_and,
       anon_sym_or,
-  [9435] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(918), 1,
-      anon_sym_SLASH,
-    ACTIONS(972), 1,
-      anon_sym_RBRACK,
-    ACTIONS(914), 3,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [9453] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(918), 1,
-      anon_sym_SLASH,
-    ACTIONS(974), 1,
-      anon_sym_RPAREN,
-    ACTIONS(914), 3,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [9471] = 5,
-    ACTIONS(3), 1,
-      sym_js_comment,
-    ACTIONS(5), 1,
-      sym_comment,
-    ACTIONS(918), 1,
-      anon_sym_SLASH,
-    ACTIONS(976), 1,
-      anon_sym_RPAREN,
-    ACTIONS(914), 3,
-      anon_sym_STAR,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [9489] = 5,
-    ACTIONS(938), 1,
+  [9723] = 5,
+    ACTIONS(948), 1,
       anon_sym_COMMA,
-    ACTIONS(978), 1,
+    ACTIONS(1004), 1,
       anon_sym_SEMI,
-    STATE(296), 1,
+    STATE(305), 1,
       aux_sym_import_statement_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(942), 2,
+    ACTIONS(952), 2,
       anon_sym_and,
       anon_sym_or,
-  [9507] = 5,
-    ACTIONS(686), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(688), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(980), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    STATE(347), 2,
-      sym_string_value,
-      sym_call_expression,
-  [9525] = 5,
+  [9741] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(918), 1,
+    ACTIONS(960), 1,
       anon_sym_SLASH,
-    ACTIONS(982), 1,
+    ACTIONS(1006), 1,
       anon_sym_RPAREN,
-    ACTIONS(914), 3,
+    ACTIONS(956), 3,
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [9543] = 6,
+  [9759] = 5,
+    ACTIONS(3), 1,
+      sym_js_comment,
+    ACTIONS(5), 1,
+      sym_comment,
+    ACTIONS(960), 1,
+      anon_sym_SLASH,
+    ACTIONS(1008), 1,
+      anon_sym_RPAREN,
+    ACTIONS(956), 3,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [9777] = 6,
     ACTIONS(239), 1,
       anon_sym_LBRACE,
-    ACTIONS(938), 1,
+    ACTIONS(948), 1,
       anon_sym_COMMA,
-    ACTIONS(984), 1,
+    ACTIONS(1010), 1,
       anon_sym_SEMI,
-    STATE(130), 1,
+    STATE(134), 1,
       sym_block,
-    STATE(288), 1,
+    STATE(291), 1,
       aux_sym_import_statement_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [9563] = 6,
-    ACTIONS(856), 1,
+  [9797] = 6,
+    ACTIONS(878), 1,
       anon_sym_LBRACE,
-    ACTIONS(938), 1,
+    ACTIONS(948), 1,
       anon_sym_COMMA,
-    ACTIONS(986), 1,
+    ACTIONS(1012), 1,
       anon_sym_SEMI,
-    STATE(146), 1,
+    STATE(142), 1,
       sym_block,
-    STATE(288), 1,
+    STATE(291), 1,
       aux_sym_import_statement_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [9583] = 5,
-    ACTIONS(686), 1,
+  [9817] = 5,
+    ACTIONS(676), 1,
       anon_sym_SQUOTE,
-    ACTIONS(688), 1,
+    ACTIONS(678), 1,
       anon_sym_DQUOTE,
-    ACTIONS(988), 1,
+    ACTIONS(1014), 1,
       sym_identifier,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    STATE(344), 2,
+    STATE(354), 2,
       sym_string_value,
       sym_call_expression,
-  [9601] = 3,
-    ACTIONS(992), 1,
-      sym_identifier,
+  [9835] = 4,
+    ACTIONS(1018), 1,
+      aux_sym_integer_value_token1,
+    STATE(318), 1,
+      sym_integer_value,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(990), 4,
-      anon_sym_has,
-      anon_sym_not,
-      anon_sym_is,
-      anon_sym_where,
-  [9615] = 5,
+    ACTIONS(1016), 3,
+      anon_sym_even,
+      anon_sym_odd,
+      sym__nth_functional_notation,
+  [9851] = 5,
     ACTIONS(3), 1,
       sym_js_comment,
     ACTIONS(5), 1,
       sym_comment,
-    ACTIONS(918), 1,
+    ACTIONS(960), 1,
       anon_sym_SLASH,
-    ACTIONS(994), 1,
+    ACTIONS(1020), 1,
       anon_sym_SEMI,
-    ACTIONS(914), 3,
+    ACTIONS(956), 3,
       anon_sym_STAR,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [9633] = 5,
-    ACTIONS(856), 1,
-      anon_sym_LBRACE,
-    ACTIONS(938), 1,
+  [9869] = 3,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(952), 2,
+      anon_sym_and,
+      anon_sym_or,
+    ACTIONS(1022), 3,
       anon_sym_COMMA,
-    STATE(98), 1,
-      sym_block,
-    STATE(288), 1,
-      aux_sym_import_statement_repeat1,
-    ACTIONS(5), 2,
+      anon_sym_SEMI,
+      anon_sym_LBRACE,
+  [9883] = 5,
+    ACTIONS(3), 1,
       sym_js_comment,
+    ACTIONS(5), 1,
       sym_comment,
-  [9650] = 2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(654), 4,
-      anon_sym_RBRACE,
-      sym_from,
-      sym_to,
-      aux_sym_integer_value_token1,
-  [9661] = 3,
-    ACTIONS(900), 1,
+    ACTIONS(960), 1,
+      anon_sym_SLASH,
+    ACTIONS(1024), 1,
+      anon_sym_RBRACK,
+    ACTIONS(956), 3,
+      anon_sym_STAR,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [9901] = 3,
+    ACTIONS(934), 1,
       anon_sym_COLON,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -12499,75 +13149,62 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_and,
       anon_sym_or,
-  [9674] = 4,
-    ACTIONS(996), 1,
-      anon_sym_COMMA,
-    STATE(278), 1,
-      aux_sym_selectors_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(884), 2,
-      anon_sym_LBRACE,
+  [9914] = 4,
+    ACTIONS(1026), 1,
       anon_sym_RPAREN,
-  [9689] = 4,
-    ACTIONS(239), 1,
-      anon_sym_LBRACE,
-    STATE(121), 1,
-      sym_block,
+    STATE(290), 1,
+      aux_sym_arguments_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(942), 2,
-      anon_sym_and,
-      anon_sym_or,
-  [9704] = 2,
+    ACTIONS(309), 2,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+  [9929] = 2,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(999), 4,
+    ACTIONS(656), 4,
       anon_sym_RBRACE,
       sym_from,
       sym_to,
       aux_sym_integer_value_token1,
-  [9715] = 4,
-    ACTIONS(1001), 1,
-      anon_sym_RPAREN,
-    STATE(287), 1,
-      aux_sym_arguments_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(309), 2,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-  [9730] = 4,
-    ACTIONS(1003), 1,
-      anon_sym_RPAREN,
-    STATE(287), 1,
-      aux_sym_arguments_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(309), 2,
-      anon_sym_COMMA,
-      anon_sym_SEMI,
-  [9745] = 5,
+  [9940] = 4,
     ACTIONS(239), 1,
       anon_sym_LBRACE,
-    ACTIONS(938), 1,
-      anon_sym_COMMA,
     STATE(125), 1,
       sym_block,
-    STATE(288), 1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(952), 2,
+      anon_sym_and,
+      anon_sym_or,
+  [9955] = 5,
+    ACTIONS(239), 1,
+      anon_sym_LBRACE,
+    ACTIONS(948), 1,
+      anon_sym_COMMA,
+    STATE(129), 1,
+      sym_block,
+    STATE(291), 1,
       aux_sym_import_statement_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [9762] = 4,
-    ACTIONS(1005), 1,
+  [9972] = 2,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(1028), 4,
+      anon_sym_RBRACE,
+      sym_from,
+      sym_to,
+      aux_sym_integer_value_token1,
+  [9983] = 4,
+    ACTIONS(1030), 1,
       anon_sym_RPAREN,
-    STATE(287), 1,
+    STATE(290), 1,
       aux_sym_arguments_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -12575,542 +13212,602 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(309), 2,
       anon_sym_COMMA,
       anon_sym_SEMI,
-  [9777] = 2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(670), 4,
-      anon_sym_RBRACE,
-      sym_from,
-      sym_to,
-      aux_sym_integer_value_token1,
-  [9788] = 2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(724), 4,
-      anon_sym_RBRACE,
-      sym_from,
-      sym_to,
-      aux_sym_integer_value_token1,
-  [9799] = 4,
-    ACTIONS(408), 1,
+  [9998] = 4,
+    ACTIONS(412), 1,
       anon_sym_RPAREN,
-    STATE(287), 1,
+    STATE(290), 1,
       aux_sym_arguments_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-    ACTIONS(1007), 2,
+    ACTIONS(1032), 2,
       anon_sym_COMMA,
       anon_sym_SEMI,
-  [9814] = 4,
-    ACTIONS(1010), 1,
-      anon_sym_COMMA,
-    STATE(288), 1,
-      aux_sym_import_statement_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(966), 2,
-      anon_sym_SEMI,
-      anon_sym_LBRACE,
-  [9829] = 4,
-    ACTIONS(856), 1,
-      anon_sym_LBRACE,
-    STATE(93), 1,
-      sym_block,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(942), 2,
-      anon_sym_and,
-      anon_sym_or,
-  [9844] = 4,
-    ACTIONS(420), 1,
-      anon_sym_COMMA,
-    ACTIONS(1013), 1,
-      anon_sym_RPAREN,
-    STATE(294), 1,
-      aux_sym_pseudo_class_arguments_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9858] = 4,
-    ACTIONS(958), 1,
-      anon_sym_RBRACK,
-    ACTIONS(1015), 1,
-      anon_sym_COMMA,
-    STATE(291), 1,
-      aux_sym_grid_value_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9872] = 4,
-    ACTIONS(862), 1,
-      anon_sym_COMMA,
-    ACTIONS(1018), 1,
-      anon_sym_LBRACE,
-    STATE(278), 1,
-      aux_sym_selectors_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9886] = 3,
-    ACTIONS(1020), 1,
-      anon_sym_RPAREN,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-    ACTIONS(942), 2,
-      anon_sym_and,
-      anon_sym_or,
-  [9898] = 4,
-    ACTIONS(450), 1,
-      anon_sym_RPAREN,
-    ACTIONS(1022), 1,
-      anon_sym_COMMA,
-    STATE(294), 1,
-      aux_sym_pseudo_class_arguments_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9912] = 4,
-    ACTIONS(912), 1,
-      anon_sym_COMMA,
-    ACTIONS(1025), 1,
-      anon_sym_RBRACK,
-    STATE(291), 1,
-      aux_sym_grid_value_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9926] = 4,
-    ACTIONS(938), 1,
-      anon_sym_COMMA,
-    ACTIONS(1027), 1,
-      anon_sym_SEMI,
-    STATE(288), 1,
-      aux_sym_import_statement_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9940] = 4,
-    ACTIONS(912), 1,
-      anon_sym_COMMA,
-    ACTIONS(1029), 1,
-      anon_sym_RBRACK,
-    STATE(291), 1,
-      aux_sym_grid_value_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9954] = 4,
-    ACTIONS(912), 1,
-      anon_sym_COMMA,
-    ACTIONS(1031), 1,
-      anon_sym_RBRACK,
-    STATE(291), 1,
-      aux_sym_grid_value_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9968] = 4,
-    ACTIONS(420), 1,
-      anon_sym_COMMA,
-    ACTIONS(1033), 1,
-      anon_sym_RPAREN,
-    STATE(294), 1,
-      aux_sym_pseudo_class_arguments_repeat1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [9982] = 4,
-    ACTIONS(938), 1,
-      anon_sym_COMMA,
+  [10013] = 4,
     ACTIONS(1035), 1,
-      anon_sym_SEMI,
-    STATE(288), 1,
+      anon_sym_COMMA,
+    STATE(291), 1,
       aux_sym_import_statement_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [9996] = 4,
-    ACTIONS(862), 1,
+    ACTIONS(1022), 2,
+      anon_sym_SEMI,
+      anon_sym_LBRACE,
+  [10028] = 4,
+    ACTIONS(1038), 1,
       anon_sym_COMMA,
-    ACTIONS(1037), 1,
-      anon_sym_RPAREN,
-    STATE(278), 1,
+    STATE(292), 1,
       aux_sym_selectors_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10010] = 3,
-    ACTIONS(1039), 1,
+    ACTIONS(906), 2,
       anon_sym_LBRACE,
-    STATE(92), 1,
-      sym_keyframe_block_list,
+      anon_sym_RPAREN,
+  [10043] = 5,
+    ACTIONS(878), 1,
+      anon_sym_LBRACE,
+    ACTIONS(948), 1,
+      anon_sym_COMMA,
+    STATE(149), 1,
+      sym_block,
+    STATE(291), 1,
+      aux_sym_import_statement_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10021] = 3,
+  [10060] = 4,
     ACTIONS(1041), 1,
-      anon_sym_LPAREN,
-    STATE(64), 1,
-      sym_pseudo_class_with_selector_arguments,
+      anon_sym_RPAREN,
+    STATE(290), 1,
+      aux_sym_arguments_repeat1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10032] = 3,
-    ACTIONS(1043), 1,
-      aux_sym_color_value_token1,
-    ACTIONS(1045), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10043] = 3,
-    ACTIONS(1047), 1,
+    ACTIONS(309), 2,
+      anon_sym_COMMA,
+      anon_sym_SEMI,
+  [10075] = 4,
+    ACTIONS(878), 1,
       anon_sym_LBRACE,
-    STATE(280), 1,
+    STATE(160), 1,
       sym_block,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10054] = 3,
-    ACTIONS(734), 1,
-      anon_sym_LBRACE,
-    ACTIONS(1049), 1,
+    ACTIONS(952), 2,
+      anon_sym_and,
+      anon_sym_or,
+  [10090] = 2,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(696), 4,
+      anon_sym_RBRACE,
+      sym_from,
+      sym_to,
+      aux_sym_integer_value_token1,
+  [10101] = 2,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(700), 4,
+      anon_sym_RBRACE,
+      sym_from,
+      sym_to,
+      aux_sym_integer_value_token1,
+  [10112] = 4,
+    ACTIONS(357), 1,
+      anon_sym_COMMA,
+    ACTIONS(1043), 1,
+      anon_sym_RPAREN,
+    STATE(301), 1,
+      aux_sym_pseudo_class_arguments_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10126] = 4,
+    ACTIONS(760), 1,
+      anon_sym_RPAREN,
+    ACTIONS(762), 1,
+      anon_sym_of,
+    ACTIONS(1045), 1,
       sym_unit,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10065] = 3,
-    ACTIONS(1045), 1,
-      sym_identifier,
-    ACTIONS(1051), 1,
+  [10140] = 4,
+    ACTIONS(948), 1,
+      anon_sym_COMMA,
+    ACTIONS(1047), 1,
+      anon_sym_SEMI,
+    STATE(291), 1,
+      aux_sym_import_statement_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10154] = 4,
+    ACTIONS(462), 1,
+      anon_sym_RPAREN,
+    ACTIONS(1049), 1,
+      anon_sym_COMMA,
+    STATE(301), 1,
+      aux_sym_pseudo_class_arguments_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10168] = 4,
+    ACTIONS(982), 1,
+      anon_sym_RBRACK,
+    ACTIONS(1052), 1,
+      anon_sym_COMMA,
+    STATE(302), 1,
+      aux_sym_grid_value_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10182] = 4,
+    ACTIONS(954), 1,
+      anon_sym_COMMA,
+    ACTIONS(1055), 1,
+      anon_sym_RBRACK,
+    STATE(302), 1,
+      aux_sym_grid_value_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10196] = 3,
+    ACTIONS(1057), 1,
+      anon_sym_RPAREN,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+    ACTIONS(952), 2,
+      anon_sym_and,
+      anon_sym_or,
+  [10208] = 4,
+    ACTIONS(948), 1,
+      anon_sym_COMMA,
+    ACTIONS(1059), 1,
+      anon_sym_SEMI,
+    STATE(291), 1,
+      aux_sym_import_statement_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10222] = 4,
+    ACTIONS(882), 1,
+      anon_sym_COMMA,
+    ACTIONS(1061), 1,
+      anon_sym_LBRACE,
+    STATE(292), 1,
+      aux_sym_selectors_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10236] = 4,
+    ACTIONS(954), 1,
+      anon_sym_COMMA,
+    ACTIONS(1063), 1,
+      anon_sym_RBRACK,
+    STATE(302), 1,
+      aux_sym_grid_value_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10250] = 4,
+    ACTIONS(954), 1,
+      anon_sym_COMMA,
+    ACTIONS(1065), 1,
+      anon_sym_RBRACK,
+    STATE(302), 1,
+      aux_sym_grid_value_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10264] = 4,
+    ACTIONS(882), 1,
+      anon_sym_COMMA,
+    ACTIONS(1067), 1,
+      anon_sym_RPAREN,
+    STATE(292), 1,
+      aux_sym_selectors_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10278] = 4,
+    ACTIONS(357), 1,
+      anon_sym_COMMA,
+    ACTIONS(1069), 1,
+      anon_sym_RPAREN,
+    STATE(301), 1,
+      aux_sym_pseudo_class_arguments_repeat1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10292] = 3,
+    ACTIONS(1071), 1,
+      anon_sym_LBRACE,
+    STATE(288), 1,
+      sym_block,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10303] = 3,
+    ACTIONS(760), 1,
+      anon_sym_LBRACE,
+    ACTIONS(1073), 1,
+      sym_unit,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10314] = 3,
+    ACTIONS(1075), 1,
       aux_sym_color_value_token1,
+    ACTIONS(1077), 1,
+      sym_identifier,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10076] = 3,
-    ACTIONS(890), 1,
-      anon_sym_LPAREN,
-    STATE(219), 1,
-      sym_arguments,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10087] = 3,
+  [10325] = 3,
     ACTIONS(239), 1,
       anon_sym_LBRACE,
-    STATE(114), 1,
+    STATE(118), 1,
       sym_block,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10098] = 3,
-    ACTIONS(856), 1,
-      anon_sym_LBRACE,
-    STATE(91), 1,
-      sym_block,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10109] = 3,
-    ACTIONS(1041), 1,
+  [10336] = 3,
+    ACTIONS(1079), 1,
       anon_sym_LPAREN,
-    STATE(61), 1,
+    STATE(63), 1,
       sym_pseudo_class_with_selector_arguments,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10120] = 3,
-    ACTIONS(1053), 1,
+  [10347] = 3,
+    ACTIONS(912), 1,
+      anon_sym_LPAREN,
+    STATE(223), 1,
+      sym_arguments,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10358] = 3,
+    ACTIONS(1079), 1,
+      anon_sym_LPAREN,
+    STATE(67), 1,
+      sym_pseudo_class_with_selector_arguments,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10369] = 3,
+    ACTIONS(1081), 1,
+      anon_sym_RPAREN,
+    ACTIONS(1083), 1,
+      anon_sym_of,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10380] = 3,
+    ACTIONS(1085), 1,
       anon_sym_LBRACE,
-    STATE(120), 1,
+    STATE(159), 1,
       sym_keyframe_block_list,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10131] = 2,
-    ACTIONS(1055), 1,
-      anon_sym_RBRACE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10139] = 2,
-    ACTIONS(1057), 1,
-      aux_sym_string_value_token2,
-    ACTIONS(3), 2,
-      sym_js_comment,
-      sym_comment,
-  [10147] = 2,
-    ACTIONS(1059), 1,
-      aux_sym_color_value_token1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10155] = 2,
-    ACTIONS(1061), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10163] = 2,
-    ACTIONS(1061), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10171] = 2,
-    ACTIONS(65), 1,
-      anon_sym_RBRACE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10179] = 2,
-    ACTIONS(1063), 1,
-      ts_builtin_sym_end,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10187] = 2,
-    ACTIONS(63), 1,
-      anon_sym_RBRACE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10195] = 2,
-    ACTIONS(1065), 1,
-      anon_sym_RBRACE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10203] = 2,
-    ACTIONS(69), 1,
-      anon_sym_RBRACE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10211] = 2,
-    ACTIONS(1067), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10219] = 2,
-    ACTIONS(1069), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10227] = 2,
-    ACTIONS(1071), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10235] = 2,
-    ACTIONS(1073), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10243] = 2,
-    ACTIONS(1075), 1,
-      anon_sym_SEMI,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10251] = 2,
-    ACTIONS(1077), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10259] = 2,
-    ACTIONS(1077), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10267] = 2,
-    ACTIONS(1079), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10275] = 2,
-    ACTIONS(1079), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10283] = 2,
-    ACTIONS(1081), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10291] = 2,
-    ACTIONS(1083), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10299] = 2,
-    ACTIONS(1085), 1,
-      anon_sym_LPAREN2,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10307] = 2,
+  [10391] = 3,
     ACTIONS(1087), 1,
-      sym_identifier,
+      anon_sym_LPAREN,
+    STATE(64), 1,
+      sym_pseudo_class_nth_child_arguments,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10315] = 2,
+  [10402] = 3,
+    ACTIONS(1077), 1,
+      sym_identifier,
     ACTIONS(1089), 1,
-      anon_sym_SEMI,
+      aux_sym_color_value_token1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10323] = 2,
+  [10413] = 3,
+    ACTIONS(878), 1,
+      anon_sym_LBRACE,
+    STATE(111), 1,
+      sym_block,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10424] = 3,
     ACTIONS(1091), 1,
-      aux_sym_color_value_token1,
+      anon_sym_LBRACE,
+    STATE(124), 1,
+      sym_keyframe_block_list,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10331] = 2,
+  [10435] = 2,
     ACTIONS(1093), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10339] = 2,
-    ACTIONS(1095), 1,
-      aux_sym_color_value_token1,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10347] = 2,
-    ACTIONS(1097), 1,
-      aux_sym_string_value_token1,
-    ACTIONS(3), 2,
-      sym_js_comment,
-      sym_comment,
-  [10355] = 2,
-    ACTIONS(1099), 1,
       aux_sym_string_value_token2,
     ACTIONS(3), 2,
       sym_js_comment,
       sym_comment,
-  [10363] = 2,
-    ACTIONS(1067), 1,
+  [10443] = 2,
+    ACTIONS(1095), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10451] = 2,
+    ACTIONS(1097), 1,
+      aux_sym_color_value_token1,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10459] = 2,
+    ACTIONS(1099), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10467] = 2,
+    ACTIONS(1099), 1,
       anon_sym_DQUOTE,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10371] = 2,
+  [10475] = 2,
     ACTIONS(1101), 1,
-      sym_identifier,
+      aux_sym_color_value_token1,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10379] = 2,
+  [10483] = 2,
     ACTIONS(1103), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10491] = 2,
+    ACTIONS(1105), 1,
       anon_sym_SEMI,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10387] = 2,
-    ACTIONS(1105), 1,
-      sym_identifier,
-    ACTIONS(5), 2,
-      sym_js_comment,
-      sym_comment,
-  [10395] = 2,
+  [10499] = 2,
     ACTIONS(1107), 1,
       anon_sym_RBRACE,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10403] = 2,
-    ACTIONS(1109), 1,
-      anon_sym_SEMI,
+  [10507] = 2,
+    ACTIONS(69), 1,
+      anon_sym_RBRACE,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10411] = 2,
-    ACTIONS(1111), 1,
-      aux_sym_string_value_token1,
-    ACTIONS(3), 2,
-      sym_js_comment,
-      sym_comment,
-  [10419] = 2,
-    ACTIONS(1113), 1,
-      aux_sym_string_value_token2,
-    ACTIONS(3), 2,
-      sym_js_comment,
-      sym_comment,
-  [10427] = 2,
-    ACTIONS(1115), 1,
+  [10515] = 2,
+    ACTIONS(1109), 1,
       sym_identifier,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10435] = 2,
+  [10523] = 2,
+    ACTIONS(1111), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10531] = 2,
+    ACTIONS(1103), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10539] = 2,
+    ACTIONS(1113), 1,
+      anon_sym_RBRACE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10547] = 2,
+    ACTIONS(67), 1,
+      anon_sym_RBRACE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10555] = 2,
+    ACTIONS(1115), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10563] = 2,
+    ACTIONS(1115), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10571] = 2,
     ACTIONS(1117), 1,
-      aux_sym_string_value_token1,
-    ACTIONS(3), 2,
+      anon_sym_SQUOTE,
+    ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10443] = 2,
+  [10579] = 2,
+    ACTIONS(1117), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10587] = 2,
     ACTIONS(1119), 1,
-      aux_sym_string_value_token1,
-    ACTIONS(3), 2,
+      anon_sym_SQUOTE,
+    ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10451] = 2,
+  [10595] = 2,
     ACTIONS(1121), 1,
       aux_sym_string_value_token2,
     ACTIONS(3), 2,
       sym_js_comment,
       sym_comment,
-  [10459] = 2,
+  [10603] = 2,
     ACTIONS(1123), 1,
-      aux_sym_string_value_token1,
-    ACTIONS(3), 2,
+      sym_identifier,
+    ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10467] = 2,
+  [10611] = 2,
     ACTIONS(1125), 1,
-      aux_sym_string_value_token2,
-    ACTIONS(3), 2,
+      aux_sym_color_value_token1,
+    ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10475] = 2,
+  [10619] = 2,
     ACTIONS(1127), 1,
       aux_sym_string_value_token1,
     ACTIONS(3), 2,
       sym_js_comment,
       sym_comment,
-  [10483] = 2,
+  [10627] = 2,
     ACTIONS(1129), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10635] = 2,
+    ACTIONS(1131), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10643] = 2,
+    ACTIONS(1133), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10651] = 2,
+    ACTIONS(1135), 1,
+      aux_sym_string_value_token1,
+    ACTIONS(3), 2,
+      sym_js_comment,
+      sym_comment,
+  [10659] = 2,
+    ACTIONS(1137), 1,
       aux_sym_string_value_token2,
     ACTIONS(3), 2,
       sym_js_comment,
       sym_comment,
-  [10491] = 2,
-    ACTIONS(1083), 1,
-      anon_sym_SQUOTE,
+  [10667] = 2,
+    ACTIONS(1139), 1,
+      anon_sym_SEMI,
     ACTIONS(5), 2,
       sym_js_comment,
       sym_comment,
-  [10499] = 2,
-    ACTIONS(1081), 1,
+  [10675] = 2,
+    ACTIONS(1141), 1,
+      anon_sym_SEMI,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10683] = 2,
+    ACTIONS(1143), 1,
+      ts_builtin_sym_end,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10691] = 2,
+    ACTIONS(1145), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10699] = 2,
+    ACTIONS(1147), 1,
+      anon_sym_LPAREN2,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10707] = 2,
+    ACTIONS(61), 1,
+      anon_sym_RBRACE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10715] = 2,
+    ACTIONS(1149), 1,
+      aux_sym_string_value_token1,
+    ACTIONS(3), 2,
+      sym_js_comment,
+      sym_comment,
+  [10723] = 2,
+    ACTIONS(1151), 1,
+      anon_sym_RBRACE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10731] = 2,
+    ACTIONS(1153), 1,
+      anon_sym_SEMI,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10739] = 2,
+    ACTIONS(1155), 1,
+      sym_identifier,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10747] = 2,
+    ACTIONS(1157), 1,
+      aux_sym_string_value_token1,
+    ACTIONS(3), 2,
+      sym_js_comment,
+      sym_comment,
+  [10755] = 2,
+    ACTIONS(1159), 1,
+      aux_sym_string_value_token2,
+    ACTIONS(3), 2,
+      sym_js_comment,
+      sym_comment,
+  [10763] = 2,
+    ACTIONS(1161), 1,
+      aux_sym_string_value_token1,
+    ACTIONS(3), 2,
+      sym_js_comment,
+      sym_comment,
+  [10771] = 2,
+    ACTIONS(1163), 1,
+      aux_sym_string_value_token2,
+    ACTIONS(3), 2,
+      sym_js_comment,
+      sym_comment,
+  [10779] = 2,
+    ACTIONS(1165), 1,
+      aux_sym_string_value_token1,
+    ACTIONS(3), 2,
+      sym_js_comment,
+      sym_comment,
+  [10787] = 2,
+    ACTIONS(1167), 1,
+      aux_sym_string_value_token2,
+    ACTIONS(3), 2,
+      sym_js_comment,
+      sym_comment,
+  [10795] = 2,
+    ACTIONS(1095), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(5), 2,
+      sym_js_comment,
+      sym_comment,
+  [10803] = 2,
+    ACTIONS(1119), 1,
       anon_sym_DQUOTE,
     ACTIONS(5), 2,
       sym_js_comment,
@@ -13144,338 +13841,349 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(25)] = 1814,
   [SMALL_STATE(26)] = 1867,
   [SMALL_STATE(27)] = 1928,
-  [SMALL_STATE(28)] = 1984,
-  [SMALL_STATE(29)] = 2034,
-  [SMALL_STATE(30)] = 2084,
-  [SMALL_STATE(31)] = 2134,
-  [SMALL_STATE(32)] = 2184,
-  [SMALL_STATE(33)] = 2230,
-  [SMALL_STATE(34)] = 2280,
-  [SMALL_STATE(35)] = 2338,
-  [SMALL_STATE(36)] = 2390,
-  [SMALL_STATE(37)] = 2446,
-  [SMALL_STATE(38)] = 2506,
-  [SMALL_STATE(39)] = 2540,
-  [SMALL_STATE(40)] = 2600,
-  [SMALL_STATE(41)] = 2638,
-  [SMALL_STATE(42)] = 2690,
-  [SMALL_STATE(43)] = 2740,
-  [SMALL_STATE(44)] = 2800,
-  [SMALL_STATE(45)] = 2850,
-  [SMALL_STATE(46)] = 2885,
-  [SMALL_STATE(47)] = 2942,
-  [SMALL_STATE(48)] = 2997,
-  [SMALL_STATE(49)] = 3032,
-  [SMALL_STATE(50)] = 3089,
-  [SMALL_STATE(51)] = 3124,
-  [SMALL_STATE(52)] = 3159,
-  [SMALL_STATE(53)] = 3213,
-  [SMALL_STATE(54)] = 3253,
-  [SMALL_STATE(55)] = 3307,
-  [SMALL_STATE(56)] = 3361,
-  [SMALL_STATE(57)] = 3415,
-  [SMALL_STATE(58)] = 3469,
-  [SMALL_STATE(59)] = 3498,
-  [SMALL_STATE(60)] = 3527,
-  [SMALL_STATE(61)] = 3556,
-  [SMALL_STATE(62)] = 3585,
-  [SMALL_STATE(63)] = 3636,
-  [SMALL_STATE(64)] = 3665,
-  [SMALL_STATE(65)] = 3694,
-  [SMALL_STATE(66)] = 3723,
-  [SMALL_STATE(67)] = 3752,
-  [SMALL_STATE(68)] = 3781,
-  [SMALL_STATE(69)] = 3810,
-  [SMALL_STATE(70)] = 3861,
-  [SMALL_STATE(71)] = 3890,
-  [SMALL_STATE(72)] = 3919,
-  [SMALL_STATE(73)] = 3948,
-  [SMALL_STATE(74)] = 3977,
-  [SMALL_STATE(75)] = 4006,
-  [SMALL_STATE(76)] = 4035,
-  [SMALL_STATE(77)] = 4064,
-  [SMALL_STATE(78)] = 4093,
-  [SMALL_STATE(79)] = 4122,
-  [SMALL_STATE(80)] = 4151,
-  [SMALL_STATE(81)] = 4186,
-  [SMALL_STATE(82)] = 4215,
-  [SMALL_STATE(83)] = 4244,
-  [SMALL_STATE(84)] = 4275,
-  [SMALL_STATE(85)] = 4304,
-  [SMALL_STATE(86)] = 4333,
-  [SMALL_STATE(87)] = 4364,
-  [SMALL_STATE(88)] = 4395,
-  [SMALL_STATE(89)] = 4426,
-  [SMALL_STATE(90)] = 4457,
-  [SMALL_STATE(91)] = 4485,
-  [SMALL_STATE(92)] = 4513,
-  [SMALL_STATE(93)] = 4541,
-  [SMALL_STATE(94)] = 4569,
-  [SMALL_STATE(95)] = 4597,
-  [SMALL_STATE(96)] = 4645,
-  [SMALL_STATE(97)] = 4673,
-  [SMALL_STATE(98)] = 4701,
-  [SMALL_STATE(99)] = 4729,
-  [SMALL_STATE(100)] = 4757,
-  [SMALL_STATE(101)] = 4785,
-  [SMALL_STATE(102)] = 4833,
-  [SMALL_STATE(103)] = 4861,
-  [SMALL_STATE(104)] = 4889,
-  [SMALL_STATE(105)] = 4917,
-  [SMALL_STATE(106)] = 4945,
-  [SMALL_STATE(107)] = 4973,
-  [SMALL_STATE(108)] = 5021,
-  [SMALL_STATE(109)] = 5049,
-  [SMALL_STATE(110)] = 5077,
-  [SMALL_STATE(111)] = 5105,
-  [SMALL_STATE(112)] = 5153,
-  [SMALL_STATE(113)] = 5201,
-  [SMALL_STATE(114)] = 5229,
-  [SMALL_STATE(115)] = 5257,
-  [SMALL_STATE(116)] = 5285,
-  [SMALL_STATE(117)] = 5333,
-  [SMALL_STATE(118)] = 5381,
-  [SMALL_STATE(119)] = 5409,
-  [SMALL_STATE(120)] = 5437,
-  [SMALL_STATE(121)] = 5465,
-  [SMALL_STATE(122)] = 5493,
-  [SMALL_STATE(123)] = 5521,
-  [SMALL_STATE(124)] = 5549,
-  [SMALL_STATE(125)] = 5577,
-  [SMALL_STATE(126)] = 5605,
-  [SMALL_STATE(127)] = 5633,
-  [SMALL_STATE(128)] = 5661,
-  [SMALL_STATE(129)] = 5689,
-  [SMALL_STATE(130)] = 5717,
-  [SMALL_STATE(131)] = 5745,
-  [SMALL_STATE(132)] = 5773,
-  [SMALL_STATE(133)] = 5801,
-  [SMALL_STATE(134)] = 5849,
-  [SMALL_STATE(135)] = 5877,
-  [SMALL_STATE(136)] = 5905,
-  [SMALL_STATE(137)] = 5937,
-  [SMALL_STATE(138)] = 5969,
-  [SMALL_STATE(139)] = 5997,
-  [SMALL_STATE(140)] = 6045,
-  [SMALL_STATE(141)] = 6093,
-  [SMALL_STATE(142)] = 6121,
-  [SMALL_STATE(143)] = 6149,
-  [SMALL_STATE(144)] = 6177,
-  [SMALL_STATE(145)] = 6205,
-  [SMALL_STATE(146)] = 6233,
-  [SMALL_STATE(147)] = 6261,
-  [SMALL_STATE(148)] = 6309,
-  [SMALL_STATE(149)] = 6357,
-  [SMALL_STATE(150)] = 6405,
-  [SMALL_STATE(151)] = 6453,
-  [SMALL_STATE(152)] = 6501,
-  [SMALL_STATE(153)] = 6549,
-  [SMALL_STATE(154)] = 6597,
-  [SMALL_STATE(155)] = 6645,
-  [SMALL_STATE(156)] = 6693,
-  [SMALL_STATE(157)] = 6741,
-  [SMALL_STATE(158)] = 6769,
-  [SMALL_STATE(159)] = 6798,
-  [SMALL_STATE(160)] = 6827,
-  [SMALL_STATE(161)] = 6856,
-  [SMALL_STATE(162)] = 6885,
-  [SMALL_STATE(163)] = 6914,
-  [SMALL_STATE(164)] = 6943,
-  [SMALL_STATE(165)] = 6972,
-  [SMALL_STATE(166)] = 7001,
-  [SMALL_STATE(167)] = 7030,
-  [SMALL_STATE(168)] = 7059,
-  [SMALL_STATE(169)] = 7088,
-  [SMALL_STATE(170)] = 7117,
-  [SMALL_STATE(171)] = 7149,
-  [SMALL_STATE(172)] = 7181,
-  [SMALL_STATE(173)] = 7211,
-  [SMALL_STATE(174)] = 7243,
-  [SMALL_STATE(175)] = 7273,
-  [SMALL_STATE(176)] = 7305,
-  [SMALL_STATE(177)] = 7335,
-  [SMALL_STATE(178)] = 7365,
-  [SMALL_STATE(179)] = 7397,
-  [SMALL_STATE(180)] = 7426,
-  [SMALL_STATE(181)] = 7455,
-  [SMALL_STATE(182)] = 7484,
-  [SMALL_STATE(183)] = 7523,
-  [SMALL_STATE(184)] = 7562,
-  [SMALL_STATE(185)] = 7591,
-  [SMALL_STATE(186)] = 7619,
-  [SMALL_STATE(187)] = 7645,
-  [SMALL_STATE(188)] = 7680,
-  [SMALL_STATE(189)] = 7702,
-  [SMALL_STATE(190)] = 7724,
-  [SMALL_STATE(191)] = 7768,
-  [SMALL_STATE(192)] = 7808,
-  [SMALL_STATE(193)] = 7852,
-  [SMALL_STATE(194)] = 7896,
-  [SMALL_STATE(195)] = 7918,
-  [SMALL_STATE(196)] = 7962,
-  [SMALL_STATE(197)] = 8001,
-  [SMALL_STATE(198)] = 8028,
-  [SMALL_STATE(199)] = 8052,
-  [SMALL_STATE(200)] = 8078,
-  [SMALL_STATE(201)] = 8104,
-  [SMALL_STATE(202)] = 8130,
-  [SMALL_STATE(203)] = 8154,
-  [SMALL_STATE(204)] = 8192,
-  [SMALL_STATE(205)] = 8218,
-  [SMALL_STATE(206)] = 8240,
-  [SMALL_STATE(207)] = 8266,
-  [SMALL_STATE(208)] = 8292,
-  [SMALL_STATE(209)] = 8318,
-  [SMALL_STATE(210)] = 8344,
-  [SMALL_STATE(211)] = 8379,
-  [SMALL_STATE(212)] = 8408,
-  [SMALL_STATE(213)] = 8429,
-  [SMALL_STATE(214)] = 8450,
-  [SMALL_STATE(215)] = 8471,
-  [SMALL_STATE(216)] = 8492,
-  [SMALL_STATE(217)] = 8513,
-  [SMALL_STATE(218)] = 8534,
-  [SMALL_STATE(219)] = 8555,
-  [SMALL_STATE(220)] = 8576,
-  [SMALL_STATE(221)] = 8597,
-  [SMALL_STATE(222)] = 8618,
-  [SMALL_STATE(223)] = 8643,
-  [SMALL_STATE(224)] = 8664,
-  [SMALL_STATE(225)] = 8686,
-  [SMALL_STATE(226)] = 8708,
-  [SMALL_STATE(227)] = 8727,
-  [SMALL_STATE(228)] = 8746,
-  [SMALL_STATE(229)] = 8765,
-  [SMALL_STATE(230)] = 8784,
-  [SMALL_STATE(231)] = 8803,
-  [SMALL_STATE(232)] = 8822,
-  [SMALL_STATE(233)] = 8841,
-  [SMALL_STATE(234)] = 8860,
-  [SMALL_STATE(235)] = 8879,
-  [SMALL_STATE(236)] = 8898,
-  [SMALL_STATE(237)] = 8917,
-  [SMALL_STATE(238)] = 8936,
-  [SMALL_STATE(239)] = 8958,
-  [SMALL_STATE(240)] = 8982,
-  [SMALL_STATE(241)] = 9004,
-  [SMALL_STATE(242)] = 9028,
-  [SMALL_STATE(243)] = 9050,
-  [SMALL_STATE(244)] = 9072,
-  [SMALL_STATE(245)] = 9096,
-  [SMALL_STATE(246)] = 9120,
-  [SMALL_STATE(247)] = 9144,
-  [SMALL_STATE(248)] = 9168,
-  [SMALL_STATE(249)] = 9190,
-  [SMALL_STATE(250)] = 9214,
-  [SMALL_STATE(251)] = 9227,
-  [SMALL_STATE(252)] = 9240,
-  [SMALL_STATE(253)] = 9253,
-  [SMALL_STATE(254)] = 9274,
-  [SMALL_STATE(255)] = 9287,
-  [SMALL_STATE(256)] = 9300,
-  [SMALL_STATE(257)] = 9319,
-  [SMALL_STATE(258)] = 9332,
-  [SMALL_STATE(259)] = 9353,
-  [SMALL_STATE(260)] = 9367,
-  [SMALL_STATE(261)] = 9385,
-  [SMALL_STATE(262)] = 9399,
-  [SMALL_STATE(263)] = 9417,
-  [SMALL_STATE(264)] = 9435,
-  [SMALL_STATE(265)] = 9453,
-  [SMALL_STATE(266)] = 9471,
-  [SMALL_STATE(267)] = 9489,
-  [SMALL_STATE(268)] = 9507,
-  [SMALL_STATE(269)] = 9525,
-  [SMALL_STATE(270)] = 9543,
-  [SMALL_STATE(271)] = 9563,
-  [SMALL_STATE(272)] = 9583,
-  [SMALL_STATE(273)] = 9601,
-  [SMALL_STATE(274)] = 9615,
-  [SMALL_STATE(275)] = 9633,
-  [SMALL_STATE(276)] = 9650,
-  [SMALL_STATE(277)] = 9661,
-  [SMALL_STATE(278)] = 9674,
-  [SMALL_STATE(279)] = 9689,
-  [SMALL_STATE(280)] = 9704,
-  [SMALL_STATE(281)] = 9715,
-  [SMALL_STATE(282)] = 9730,
-  [SMALL_STATE(283)] = 9745,
-  [SMALL_STATE(284)] = 9762,
-  [SMALL_STATE(285)] = 9777,
-  [SMALL_STATE(286)] = 9788,
-  [SMALL_STATE(287)] = 9799,
-  [SMALL_STATE(288)] = 9814,
-  [SMALL_STATE(289)] = 9829,
-  [SMALL_STATE(290)] = 9844,
-  [SMALL_STATE(291)] = 9858,
-  [SMALL_STATE(292)] = 9872,
-  [SMALL_STATE(293)] = 9886,
-  [SMALL_STATE(294)] = 9898,
-  [SMALL_STATE(295)] = 9912,
-  [SMALL_STATE(296)] = 9926,
-  [SMALL_STATE(297)] = 9940,
-  [SMALL_STATE(298)] = 9954,
-  [SMALL_STATE(299)] = 9968,
-  [SMALL_STATE(300)] = 9982,
-  [SMALL_STATE(301)] = 9996,
-  [SMALL_STATE(302)] = 10010,
-  [SMALL_STATE(303)] = 10021,
-  [SMALL_STATE(304)] = 10032,
-  [SMALL_STATE(305)] = 10043,
-  [SMALL_STATE(306)] = 10054,
-  [SMALL_STATE(307)] = 10065,
-  [SMALL_STATE(308)] = 10076,
-  [SMALL_STATE(309)] = 10087,
-  [SMALL_STATE(310)] = 10098,
-  [SMALL_STATE(311)] = 10109,
-  [SMALL_STATE(312)] = 10120,
-  [SMALL_STATE(313)] = 10131,
-  [SMALL_STATE(314)] = 10139,
-  [SMALL_STATE(315)] = 10147,
-  [SMALL_STATE(316)] = 10155,
-  [SMALL_STATE(317)] = 10163,
-  [SMALL_STATE(318)] = 10171,
-  [SMALL_STATE(319)] = 10179,
-  [SMALL_STATE(320)] = 10187,
-  [SMALL_STATE(321)] = 10195,
-  [SMALL_STATE(322)] = 10203,
-  [SMALL_STATE(323)] = 10211,
-  [SMALL_STATE(324)] = 10219,
-  [SMALL_STATE(325)] = 10227,
-  [SMALL_STATE(326)] = 10235,
-  [SMALL_STATE(327)] = 10243,
-  [SMALL_STATE(328)] = 10251,
-  [SMALL_STATE(329)] = 10259,
-  [SMALL_STATE(330)] = 10267,
-  [SMALL_STATE(331)] = 10275,
-  [SMALL_STATE(332)] = 10283,
-  [SMALL_STATE(333)] = 10291,
-  [SMALL_STATE(334)] = 10299,
-  [SMALL_STATE(335)] = 10307,
-  [SMALL_STATE(336)] = 10315,
-  [SMALL_STATE(337)] = 10323,
-  [SMALL_STATE(338)] = 10331,
-  [SMALL_STATE(339)] = 10339,
-  [SMALL_STATE(340)] = 10347,
-  [SMALL_STATE(341)] = 10355,
-  [SMALL_STATE(342)] = 10363,
-  [SMALL_STATE(343)] = 10371,
-  [SMALL_STATE(344)] = 10379,
-  [SMALL_STATE(345)] = 10387,
-  [SMALL_STATE(346)] = 10395,
-  [SMALL_STATE(347)] = 10403,
-  [SMALL_STATE(348)] = 10411,
-  [SMALL_STATE(349)] = 10419,
-  [SMALL_STATE(350)] = 10427,
-  [SMALL_STATE(351)] = 10435,
-  [SMALL_STATE(352)] = 10443,
-  [SMALL_STATE(353)] = 10451,
-  [SMALL_STATE(354)] = 10459,
-  [SMALL_STATE(355)] = 10467,
-  [SMALL_STATE(356)] = 10475,
-  [SMALL_STATE(357)] = 10483,
-  [SMALL_STATE(358)] = 10491,
-  [SMALL_STATE(359)] = 10499,
+  [SMALL_STATE(28)] = 1980,
+  [SMALL_STATE(29)] = 2036,
+  [SMALL_STATE(30)] = 2096,
+  [SMALL_STATE(31)] = 2146,
+  [SMALL_STATE(32)] = 2196,
+  [SMALL_STATE(33)] = 2246,
+  [SMALL_STATE(34)] = 2296,
+  [SMALL_STATE(35)] = 2342,
+  [SMALL_STATE(36)] = 2400,
+  [SMALL_STATE(37)] = 2460,
+  [SMALL_STATE(38)] = 2516,
+  [SMALL_STATE(39)] = 2576,
+  [SMALL_STATE(40)] = 2610,
+  [SMALL_STATE(41)] = 2648,
+  [SMALL_STATE(42)] = 2698,
+  [SMALL_STATE(43)] = 2748,
+  [SMALL_STATE(44)] = 2798,
+  [SMALL_STATE(45)] = 2848,
+  [SMALL_STATE(46)] = 2900,
+  [SMALL_STATE(47)] = 2935,
+  [SMALL_STATE(48)] = 2992,
+  [SMALL_STATE(49)] = 3027,
+  [SMALL_STATE(50)] = 3062,
+  [SMALL_STATE(51)] = 3117,
+  [SMALL_STATE(52)] = 3174,
+  [SMALL_STATE(53)] = 3209,
+  [SMALL_STATE(54)] = 3249,
+  [SMALL_STATE(55)] = 3303,
+  [SMALL_STATE(56)] = 3357,
+  [SMALL_STATE(57)] = 3411,
+  [SMALL_STATE(58)] = 3465,
+  [SMALL_STATE(59)] = 3519,
+  [SMALL_STATE(60)] = 3548,
+  [SMALL_STATE(61)] = 3579,
+  [SMALL_STATE(62)] = 3608,
+  [SMALL_STATE(63)] = 3637,
+  [SMALL_STATE(64)] = 3666,
+  [SMALL_STATE(65)] = 3695,
+  [SMALL_STATE(66)] = 3746,
+  [SMALL_STATE(67)] = 3775,
+  [SMALL_STATE(68)] = 3804,
+  [SMALL_STATE(69)] = 3833,
+  [SMALL_STATE(70)] = 3862,
+  [SMALL_STATE(71)] = 3891,
+  [SMALL_STATE(72)] = 3920,
+  [SMALL_STATE(73)] = 3949,
+  [SMALL_STATE(74)] = 4000,
+  [SMALL_STATE(75)] = 4029,
+  [SMALL_STATE(76)] = 4058,
+  [SMALL_STATE(77)] = 4087,
+  [SMALL_STATE(78)] = 4116,
+  [SMALL_STATE(79)] = 4145,
+  [SMALL_STATE(80)] = 4174,
+  [SMALL_STATE(81)] = 4203,
+  [SMALL_STATE(82)] = 4232,
+  [SMALL_STATE(83)] = 4261,
+  [SMALL_STATE(84)] = 4290,
+  [SMALL_STATE(85)] = 4325,
+  [SMALL_STATE(86)] = 4354,
+  [SMALL_STATE(87)] = 4383,
+  [SMALL_STATE(88)] = 4414,
+  [SMALL_STATE(89)] = 4443,
+  [SMALL_STATE(90)] = 4472,
+  [SMALL_STATE(91)] = 4501,
+  [SMALL_STATE(92)] = 4530,
+  [SMALL_STATE(93)] = 4559,
+  [SMALL_STATE(94)] = 4590,
+  [SMALL_STATE(95)] = 4621,
+  [SMALL_STATE(96)] = 4652,
+  [SMALL_STATE(97)] = 4680,
+  [SMALL_STATE(98)] = 4708,
+  [SMALL_STATE(99)] = 4756,
+  [SMALL_STATE(100)] = 4784,
+  [SMALL_STATE(101)] = 4812,
+  [SMALL_STATE(102)] = 4860,
+  [SMALL_STATE(103)] = 4888,
+  [SMALL_STATE(104)] = 4936,
+  [SMALL_STATE(105)] = 4984,
+  [SMALL_STATE(106)] = 5012,
+  [SMALL_STATE(107)] = 5040,
+  [SMALL_STATE(108)] = 5068,
+  [SMALL_STATE(109)] = 5096,
+  [SMALL_STATE(110)] = 5144,
+  [SMALL_STATE(111)] = 5192,
+  [SMALL_STATE(112)] = 5220,
+  [SMALL_STATE(113)] = 5248,
+  [SMALL_STATE(114)] = 5276,
+  [SMALL_STATE(115)] = 5304,
+  [SMALL_STATE(116)] = 5332,
+  [SMALL_STATE(117)] = 5380,
+  [SMALL_STATE(118)] = 5408,
+  [SMALL_STATE(119)] = 5436,
+  [SMALL_STATE(120)] = 5464,
+  [SMALL_STATE(121)] = 5512,
+  [SMALL_STATE(122)] = 5540,
+  [SMALL_STATE(123)] = 5568,
+  [SMALL_STATE(124)] = 5596,
+  [SMALL_STATE(125)] = 5624,
+  [SMALL_STATE(126)] = 5652,
+  [SMALL_STATE(127)] = 5680,
+  [SMALL_STATE(128)] = 5708,
+  [SMALL_STATE(129)] = 5736,
+  [SMALL_STATE(130)] = 5764,
+  [SMALL_STATE(131)] = 5792,
+  [SMALL_STATE(132)] = 5820,
+  [SMALL_STATE(133)] = 5848,
+  [SMALL_STATE(134)] = 5876,
+  [SMALL_STATE(135)] = 5904,
+  [SMALL_STATE(136)] = 5932,
+  [SMALL_STATE(137)] = 5960,
+  [SMALL_STATE(138)] = 5988,
+  [SMALL_STATE(139)] = 6016,
+  [SMALL_STATE(140)] = 6064,
+  [SMALL_STATE(141)] = 6096,
+  [SMALL_STATE(142)] = 6128,
+  [SMALL_STATE(143)] = 6156,
+  [SMALL_STATE(144)] = 6204,
+  [SMALL_STATE(145)] = 6252,
+  [SMALL_STATE(146)] = 6280,
+  [SMALL_STATE(147)] = 6308,
+  [SMALL_STATE(148)] = 6356,
+  [SMALL_STATE(149)] = 6404,
+  [SMALL_STATE(150)] = 6432,
+  [SMALL_STATE(151)] = 6460,
+  [SMALL_STATE(152)] = 6488,
+  [SMALL_STATE(153)] = 6516,
+  [SMALL_STATE(154)] = 6544,
+  [SMALL_STATE(155)] = 6592,
+  [SMALL_STATE(156)] = 6640,
+  [SMALL_STATE(157)] = 6688,
+  [SMALL_STATE(158)] = 6736,
+  [SMALL_STATE(159)] = 6784,
+  [SMALL_STATE(160)] = 6812,
+  [SMALL_STATE(161)] = 6840,
+  [SMALL_STATE(162)] = 6888,
+  [SMALL_STATE(163)] = 6936,
+  [SMALL_STATE(164)] = 6964,
+  [SMALL_STATE(165)] = 6993,
+  [SMALL_STATE(166)] = 7022,
+  [SMALL_STATE(167)] = 7051,
+  [SMALL_STATE(168)] = 7080,
+  [SMALL_STATE(169)] = 7109,
+  [SMALL_STATE(170)] = 7138,
+  [SMALL_STATE(171)] = 7167,
+  [SMALL_STATE(172)] = 7196,
+  [SMALL_STATE(173)] = 7225,
+  [SMALL_STATE(174)] = 7254,
+  [SMALL_STATE(175)] = 7283,
+  [SMALL_STATE(176)] = 7312,
+  [SMALL_STATE(177)] = 7344,
+  [SMALL_STATE(178)] = 7376,
+  [SMALL_STATE(179)] = 7406,
+  [SMALL_STATE(180)] = 7438,
+  [SMALL_STATE(181)] = 7470,
+  [SMALL_STATE(182)] = 7500,
+  [SMALL_STATE(183)] = 7530,
+  [SMALL_STATE(184)] = 7560,
+  [SMALL_STATE(185)] = 7592,
+  [SMALL_STATE(186)] = 7621,
+  [SMALL_STATE(187)] = 7650,
+  [SMALL_STATE(188)] = 7679,
+  [SMALL_STATE(189)] = 7718,
+  [SMALL_STATE(190)] = 7747,
+  [SMALL_STATE(191)] = 7786,
+  [SMALL_STATE(192)] = 7814,
+  [SMALL_STATE(193)] = 7840,
+  [SMALL_STATE(194)] = 7875,
+  [SMALL_STATE(195)] = 7897,
+  [SMALL_STATE(196)] = 7941,
+  [SMALL_STATE(197)] = 7985,
+  [SMALL_STATE(198)] = 8025,
+  [SMALL_STATE(199)] = 8069,
+  [SMALL_STATE(200)] = 8091,
+  [SMALL_STATE(201)] = 8113,
+  [SMALL_STATE(202)] = 8157,
+  [SMALL_STATE(203)] = 8196,
+  [SMALL_STATE(204)] = 8223,
+  [SMALL_STATE(205)] = 8261,
+  [SMALL_STATE(206)] = 8287,
+  [SMALL_STATE(207)] = 8313,
+  [SMALL_STATE(208)] = 8337,
+  [SMALL_STATE(209)] = 8361,
+  [SMALL_STATE(210)] = 8399,
+  [SMALL_STATE(211)] = 8421,
+  [SMALL_STATE(212)] = 8447,
+  [SMALL_STATE(213)] = 8473,
+  [SMALL_STATE(214)] = 8499,
+  [SMALL_STATE(215)] = 8525,
+  [SMALL_STATE(216)] = 8551,
+  [SMALL_STATE(217)] = 8577,
+  [SMALL_STATE(218)] = 8598,
+  [SMALL_STATE(219)] = 8619,
+  [SMALL_STATE(220)] = 8640,
+  [SMALL_STATE(221)] = 8663,
+  [SMALL_STATE(222)] = 8684,
+  [SMALL_STATE(223)] = 8705,
+  [SMALL_STATE(224)] = 8726,
+  [SMALL_STATE(225)] = 8761,
+  [SMALL_STATE(226)] = 8784,
+  [SMALL_STATE(227)] = 8809,
+  [SMALL_STATE(228)] = 8838,
+  [SMALL_STATE(229)] = 8859,
+  [SMALL_STATE(230)] = 8880,
+  [SMALL_STATE(231)] = 8901,
+  [SMALL_STATE(232)] = 8922,
+  [SMALL_STATE(233)] = 8943,
+  [SMALL_STATE(234)] = 8965,
+  [SMALL_STATE(235)] = 8987,
+  [SMALL_STATE(236)] = 9007,
+  [SMALL_STATE(237)] = 9026,
+  [SMALL_STATE(238)] = 9045,
+  [SMALL_STATE(239)] = 9064,
+  [SMALL_STATE(240)] = 9083,
+  [SMALL_STATE(241)] = 9102,
+  [SMALL_STATE(242)] = 9121,
+  [SMALL_STATE(243)] = 9140,
+  [SMALL_STATE(244)] = 9159,
+  [SMALL_STATE(245)] = 9178,
+  [SMALL_STATE(246)] = 9197,
+  [SMALL_STATE(247)] = 9216,
+  [SMALL_STATE(248)] = 9238,
+  [SMALL_STATE(249)] = 9262,
+  [SMALL_STATE(250)] = 9286,
+  [SMALL_STATE(251)] = 9310,
+  [SMALL_STATE(252)] = 9332,
+  [SMALL_STATE(253)] = 9354,
+  [SMALL_STATE(254)] = 9378,
+  [SMALL_STATE(255)] = 9402,
+  [SMALL_STATE(256)] = 9424,
+  [SMALL_STATE(257)] = 9448,
+  [SMALL_STATE(258)] = 9472,
+  [SMALL_STATE(259)] = 9494,
+  [SMALL_STATE(260)] = 9515,
+  [SMALL_STATE(261)] = 9534,
+  [SMALL_STATE(262)] = 9547,
+  [SMALL_STATE(263)] = 9568,
+  [SMALL_STATE(264)] = 9581,
+  [SMALL_STATE(265)] = 9594,
+  [SMALL_STATE(266)] = 9607,
+  [SMALL_STATE(267)] = 9620,
+  [SMALL_STATE(268)] = 9633,
+  [SMALL_STATE(269)] = 9651,
+  [SMALL_STATE(270)] = 9669,
+  [SMALL_STATE(271)] = 9687,
+  [SMALL_STATE(272)] = 9705,
+  [SMALL_STATE(273)] = 9723,
+  [SMALL_STATE(274)] = 9741,
+  [SMALL_STATE(275)] = 9759,
+  [SMALL_STATE(276)] = 9777,
+  [SMALL_STATE(277)] = 9797,
+  [SMALL_STATE(278)] = 9817,
+  [SMALL_STATE(279)] = 9835,
+  [SMALL_STATE(280)] = 9851,
+  [SMALL_STATE(281)] = 9869,
+  [SMALL_STATE(282)] = 9883,
+  [SMALL_STATE(283)] = 9901,
+  [SMALL_STATE(284)] = 9914,
+  [SMALL_STATE(285)] = 9929,
+  [SMALL_STATE(286)] = 9940,
+  [SMALL_STATE(287)] = 9955,
+  [SMALL_STATE(288)] = 9972,
+  [SMALL_STATE(289)] = 9983,
+  [SMALL_STATE(290)] = 9998,
+  [SMALL_STATE(291)] = 10013,
+  [SMALL_STATE(292)] = 10028,
+  [SMALL_STATE(293)] = 10043,
+  [SMALL_STATE(294)] = 10060,
+  [SMALL_STATE(295)] = 10075,
+  [SMALL_STATE(296)] = 10090,
+  [SMALL_STATE(297)] = 10101,
+  [SMALL_STATE(298)] = 10112,
+  [SMALL_STATE(299)] = 10126,
+  [SMALL_STATE(300)] = 10140,
+  [SMALL_STATE(301)] = 10154,
+  [SMALL_STATE(302)] = 10168,
+  [SMALL_STATE(303)] = 10182,
+  [SMALL_STATE(304)] = 10196,
+  [SMALL_STATE(305)] = 10208,
+  [SMALL_STATE(306)] = 10222,
+  [SMALL_STATE(307)] = 10236,
+  [SMALL_STATE(308)] = 10250,
+  [SMALL_STATE(309)] = 10264,
+  [SMALL_STATE(310)] = 10278,
+  [SMALL_STATE(311)] = 10292,
+  [SMALL_STATE(312)] = 10303,
+  [SMALL_STATE(313)] = 10314,
+  [SMALL_STATE(314)] = 10325,
+  [SMALL_STATE(315)] = 10336,
+  [SMALL_STATE(316)] = 10347,
+  [SMALL_STATE(317)] = 10358,
+  [SMALL_STATE(318)] = 10369,
+  [SMALL_STATE(319)] = 10380,
+  [SMALL_STATE(320)] = 10391,
+  [SMALL_STATE(321)] = 10402,
+  [SMALL_STATE(322)] = 10413,
+  [SMALL_STATE(323)] = 10424,
+  [SMALL_STATE(324)] = 10435,
+  [SMALL_STATE(325)] = 10443,
+  [SMALL_STATE(326)] = 10451,
+  [SMALL_STATE(327)] = 10459,
+  [SMALL_STATE(328)] = 10467,
+  [SMALL_STATE(329)] = 10475,
+  [SMALL_STATE(330)] = 10483,
+  [SMALL_STATE(331)] = 10491,
+  [SMALL_STATE(332)] = 10499,
+  [SMALL_STATE(333)] = 10507,
+  [SMALL_STATE(334)] = 10515,
+  [SMALL_STATE(335)] = 10523,
+  [SMALL_STATE(336)] = 10531,
+  [SMALL_STATE(337)] = 10539,
+  [SMALL_STATE(338)] = 10547,
+  [SMALL_STATE(339)] = 10555,
+  [SMALL_STATE(340)] = 10563,
+  [SMALL_STATE(341)] = 10571,
+  [SMALL_STATE(342)] = 10579,
+  [SMALL_STATE(343)] = 10587,
+  [SMALL_STATE(344)] = 10595,
+  [SMALL_STATE(345)] = 10603,
+  [SMALL_STATE(346)] = 10611,
+  [SMALL_STATE(347)] = 10619,
+  [SMALL_STATE(348)] = 10627,
+  [SMALL_STATE(349)] = 10635,
+  [SMALL_STATE(350)] = 10643,
+  [SMALL_STATE(351)] = 10651,
+  [SMALL_STATE(352)] = 10659,
+  [SMALL_STATE(353)] = 10667,
+  [SMALL_STATE(354)] = 10675,
+  [SMALL_STATE(355)] = 10683,
+  [SMALL_STATE(356)] = 10691,
+  [SMALL_STATE(357)] = 10699,
+  [SMALL_STATE(358)] = 10707,
+  [SMALL_STATE(359)] = 10715,
+  [SMALL_STATE(360)] = 10723,
+  [SMALL_STATE(361)] = 10731,
+  [SMALL_STATE(362)] = 10739,
+  [SMALL_STATE(363)] = 10747,
+  [SMALL_STATE(364)] = 10755,
+  [SMALL_STATE(365)] = 10763,
+  [SMALL_STATE(366)] = 10771,
+  [SMALL_STATE(367)] = 10779,
+  [SMALL_STATE(368)] = 10787,
+  [SMALL_STATE(369)] = 10795,
+  [SMALL_STATE(370)] = 10803,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -13484,536 +14192,555 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [7] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_stylesheet, 0, 0, 0),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(117),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(200),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(153),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(268),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(325),
-  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(201),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(206),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(101),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(269),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(335),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(205),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
   [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(345),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(314),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
-  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(187),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
-  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(148),
-  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(209),
-  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(149),
-  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(272),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(338),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(199),
-  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(334),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(193),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(225),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(154),
+  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(215),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(155),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(278),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(349),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(216),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(199),
   [59] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(285),
-  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(286),
-  [71] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(148),
-  [74] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(209),
-  [77] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(149),
-  [80] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(272),
-  [83] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(338),
+  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(296),
+  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
+  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(297),
+  [71] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(154),
+  [74] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(215),
+  [77] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(155),
+  [80] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(278),
+  [83] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(349),
   [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0),
-  [88] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(199),
-  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(192),
-  [94] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(78),
-  [97] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(326),
+  [88] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(216),
+  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(195),
+  [94] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(88),
+  [97] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(356),
   [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(345),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(350),
-  [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(41),
-  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(351),
-  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(314),
+  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(334),
+  [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
+  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(347),
+  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(344),
   [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(194),
   [118] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(16),
-  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(273),
-  [124] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_stylesheet, 1, 0, 0),
-  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0),
-  [128] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(117),
-  [131] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(200),
-  [134] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(153),
-  [137] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(268),
-  [140] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(325),
-  [143] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(201),
-  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(192),
-  [149] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(78),
-  [152] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(326),
-  [155] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(345),
-  [158] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(350),
-  [161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(41),
-  [164] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(351),
-  [167] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(314),
-  [170] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(188),
-  [173] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(187),
-  [176] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(273),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
-  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(326),
-  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
+  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(225),
+  [124] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0),
+  [126] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(116),
+  [129] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(206),
+  [132] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(101),
+  [135] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(269),
+  [138] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(335),
+  [141] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(205),
+  [144] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(195),
+  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(88),
+  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(356),
+  [153] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(345),
+  [156] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(334),
+  [159] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
+  [162] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(347),
+  [165] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(344),
+  [168] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(200),
+  [171] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(193),
+  [174] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_repeat1, 2, 0, 0), SHIFT_REPEAT(225),
+  [177] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_stylesheet, 1, 0, 0),
+  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
+  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(356),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
   [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
-  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
-  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(355),
-  [197] = {.entry = {.count = 1, .reusable = false}}, SHIFT(136),
-  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
+  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
+  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
+  [197] = {.entry = {.count = 1, .reusable = false}}, SHIFT(140),
+  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(141),
   [201] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(170),
-  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
-  [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
-  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
-  [213] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
+  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(179),
+  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
+  [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
+  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
+  [213] = {.entry = {.count = 1, .reusable = true}}, SHIFT(313),
   [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
-  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
-  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(357),
-  [225] = {.entry = {.count = 1, .reusable = false}}, SHIFT(225),
-  [227] = {.entry = {.count = 1, .reusable = false}}, SHIFT(224),
-  [229] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [231] = {.entry = {.count = 1, .reusable = false}}, SHIFT(239),
-  [233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
-  [235] = {.entry = {.count = 1, .reusable = false}}, SHIFT(245),
-  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [241] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(315),
-  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [249] = {.entry = {.count = 1, .reusable = false}}, SHIFT(334),
-  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
-  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
+  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
+  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(367),
+  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
+  [225] = {.entry = {.count = 1, .reusable = false}}, SHIFT(233),
+  [227] = {.entry = {.count = 1, .reusable = false}}, SHIFT(234),
+  [229] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [231] = {.entry = {.count = 1, .reusable = false}}, SHIFT(254),
+  [233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
+  [235] = {.entry = {.count = 1, .reusable = false}}, SHIFT(256),
+  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [241] = {.entry = {.count = 1, .reusable = false}}, SHIFT(211),
+  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
+  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [249] = {.entry = {.count = 1, .reusable = false}}, SHIFT(357),
+  [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
+  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
   [255] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
-  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(337),
-  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
-  [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(348),
-  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(349),
-  [269] = {.entry = {.count = 1, .reusable = false}}, SHIFT(211),
-  [271] = {.entry = {.count = 1, .reusable = false}}, SHIFT(266),
-  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
-  [275] = {.entry = {.count = 1, .reusable = false}}, SHIFT(269),
-  [277] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
-  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(329),
+  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
+  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
+  [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
+  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(324),
+  [269] = {.entry = {.count = 1, .reusable = false}}, SHIFT(227),
+  [271] = {.entry = {.count = 1, .reusable = false}}, SHIFT(275),
+  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
+  [275] = {.entry = {.count = 1, .reusable = false}}, SHIFT(271),
+  [277] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
   [281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_last_declaration, 3, 0, 14),
-  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(139),
-  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
-  [289] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
-  [291] = {.entry = {.count = 1, .reusable = false}}, SHIFT(175),
-  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
-  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
+  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(143),
+  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [289] = {.entry = {.count = 1, .reusable = false}}, SHIFT(84),
+  [291] = {.entry = {.count = 1, .reusable = false}}, SHIFT(177),
+  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
   [299] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__selector, 1, 0, 1),
   [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__value, 1, 0, 3),
   [303] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__selector, 1, 0, 1),
-  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
   [307] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__value, 1, 0, 3),
-  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
   [311] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
-  [315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
-  [317] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [319] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
-  [323] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0),
-  [325] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(315),
-  [328] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(155),
-  [331] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(170),
-  [334] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(156),
-  [337] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(352),
-  [340] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(353),
-  [343] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(136),
-  [346] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(137),
-  [349] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(80),
-  [352] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(170),
-  [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
-  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [361] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [363] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [365] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [367] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [369] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [371] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(107),
-  [374] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0),
-  [376] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(315),
-  [379] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(155),
-  [382] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(175),
-  [385] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(156),
-  [388] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(352),
-  [391] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(353),
-  [394] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(136),
-  [397] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(137),
-  [400] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(80),
-  [403] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(175),
-  [406] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [408] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0),
-  [410] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
-  [412] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_last_declaration, 4, 0, 14),
-  [414] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
-  [416] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string_value, 3, 0, 0),
-  [418] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string_value, 3, 0, 0),
-  [420] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(230),
+  [315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
+  [317] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [319] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
+  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [325] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0),
+  [327] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(326),
+  [330] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(161),
+  [333] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(179),
+  [336] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(162),
+  [339] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(363),
+  [342] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(364),
+  [345] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(140),
+  [348] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(141),
+  [351] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(84),
+  [354] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(179),
+  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [361] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [363] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [365] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [367] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
+  [369] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [371] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [373] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [375] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(98),
+  [378] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0),
+  [380] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(326),
+  [383] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(161),
+  [386] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(177),
+  [389] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(162),
+  [392] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(363),
+  [395] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(364),
+  [398] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(140),
+  [401] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(141),
+  [404] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(84),
+  [407] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(177),
+  [410] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [412] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0),
+  [414] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [416] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_last_declaration, 4, 0, 14),
+  [418] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [420] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string_value, 3, 0, 0),
+  [422] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string_value, 3, 0, 0),
   [424] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__selector, 1, 0, 0),
   [426] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__value, 1, 0, 0),
   [428] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__selector, 1, 0, 0),
   [430] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__value, 1, 0, 0),
-  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [434] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
-  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [438] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [440] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_selector, 3, 0, 11),
-  [442] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_selector, 3, 0, 11),
-  [444] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
-  [448] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
-  [450] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_pseudo_class_arguments_repeat1, 2, 0, 0),
+  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [434] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
+  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
+  [438] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [440] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [442] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 3, 0, 10),
+  [444] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 3, 0, 10),
+  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [448] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [450] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
   [452] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_selector, 2, 0, 5),
   [454] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_selector, 2, 0, 5),
-  [456] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
-  [458] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 3, 0, 10),
-  [460] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 3, 0, 10),
-  [462] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [464] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 2, 0, 2),
-  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 2, 0, 2),
-  [468] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
+  [456] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [458] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_selector, 3, 0, 11),
+  [460] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_selector, 3, 0, 11),
+  [462] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_pseudo_class_arguments_repeat1, 2, 0, 0),
+  [464] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
+  [466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 2, 0, 2),
+  [468] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 2, 0, 2),
   [470] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__query, 1, 0, 4),
   [472] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__query, 1, 0, 4),
-  [474] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
-  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
-  [480] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
-  [482] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_selector, 5, 0, 9),
-  [484] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_selector, 5, 0, 9),
-  [486] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_with_selector_arguments, 2, 0, 0),
-  [488] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_with_selector_arguments, 2, 0, 0),
-  [490] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_arguments, 2, 0, 0),
-  [492] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_arguments, 2, 0, 0),
-  [494] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 3, 0, 2),
-  [496] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 3, 0, 2),
-  [498] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_arguments, 2, 0, 0),
-  [500] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_arguments, 2, 0, 0),
-  [502] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 4, 0, 10),
-  [504] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 4, 0, 10),
-  [506] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_selector, 4, 0, 11),
-  [508] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_selector, 4, 0, 11),
-  [510] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_selector, 4, 0, 15),
-  [512] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_selector, 4, 0, 15),
-  [514] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_with_selector_arguments, 3, 0, 0),
-  [516] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_with_selector_arguments, 3, 0, 0),
-  [518] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_arguments, 3, 0, 0),
-  [520] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_arguments, 3, 0, 0),
-  [522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_selector, 3, 0, 5),
-  [524] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_selector, 3, 0, 5),
-  [526] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_arguments, 3, 0, 0),
-  [528] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_arguments, 3, 0, 0),
-  [530] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_selector, 3, 0, 9),
-  [532] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_selector, 3, 0, 9),
-  [534] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_with_selector_arguments, 4, 0, 0),
-  [536] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_with_selector_arguments, 4, 0, 0),
-  [538] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_selector, 2, 0, 2),
-  [540] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_selector, 2, 0, 2),
-  [542] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_arguments, 4, 0, 0),
-  [544] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_arguments, 4, 0, 0),
-  [546] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_arguments, 4, 0, 0),
-  [548] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_arguments, 4, 0, 0),
-  [550] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_universal_selector, 1, 0, 0),
-  [552] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_universal_selector, 1, 0, 0),
-  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_selector, 6, 0, 15),
-  [556] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_selector, 6, 0, 15),
-  [558] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_id_selector, 2, 0, 6),
-  [560] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_id_selector, 2, 0, 6),
-  [562] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_descendant_selector, 3, 0, 0),
-  [564] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
-  [566] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_descendant_selector, 3, 0, 0),
-  [568] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_selector, 3, 0, 10),
-  [570] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_selector, 3, 0, 10),
-  [572] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_id_selector, 3, 0, 12),
-  [574] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_id_selector, 3, 0, 12),
-  [576] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_child_selector, 3, 0, 0),
-  [578] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_child_selector, 3, 0, 0),
-  [580] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_sibling_selector, 3, 0, 0),
-  [582] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_sibling_selector, 3, 0, 0),
-  [584] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_adjacent_sibling_selector, 3, 0, 0),
-  [586] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_adjacent_sibling_selector, 3, 0, 0),
-  [588] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_selector, 3, 0, 0),
-  [590] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_selector, 3, 0, 0),
-  [592] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_media_statement, 3, 0, 0),
-  [594] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_media_statement, 3, 0, 0),
-  [596] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_rule_set, 2, 0, 0),
-  [598] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_rule_set, 2, 0, 0),
-  [600] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyframes_statement, 3, 0, 8),
-  [602] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyframes_statement, 3, 0, 8),
-  [604] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_supports_statement, 3, 0, 0),
-  [606] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_supports_statement, 3, 0, 0),
-  [608] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_statement, 4, 0, 0),
-  [610] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_import_statement, 4, 0, 0),
-  [612] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
-  [614] = {.entry = {.count = 1, .reusable = false}}, SHIFT(222),
-  [616] = {.entry = {.count = 1, .reusable = false}}, SHIFT(265),
-  [618] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_at_rule, 2, 0, 0),
-  [620] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_at_rule, 2, 0, 0),
-  [622] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_statement, 5, 0, 0),
-  [624] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_import_statement, 5, 0, 0),
-  [626] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_media_statement, 4, 0, 0),
-  [628] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_media_statement, 4, 0, 0),
-  [630] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyframe_block_list, 3, 0, 0),
-  [632] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyframe_block_list, 3, 0, 0),
-  [634] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 4, 0, 13),
-  [636] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 4, 0, 13),
-  [638] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
-  [640] = {.entry = {.count = 1, .reusable = false}}, SHIFT(260),
-  [642] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declaration, 5, 0, 14),
-  [644] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_declaration, 5, 0, 14),
-  [646] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyframe_block_list, 2, 0, 0),
-  [648] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyframe_block_list, 2, 0, 0),
-  [650] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_postcss_statement, 3, 0, 0),
-  [652] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_postcss_statement, 3, 0, 0),
-  [654] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, 0, 0),
-  [656] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, 0, 0),
-  [658] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_statement, 3, 0, 0),
-  [660] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_import_statement, 3, 0, 0),
-  [662] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [664] = {.entry = {.count = 1, .reusable = false}}, SHIFT(171),
-  [666] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declaration, 4, 0, 14),
-  [668] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_declaration, 4, 0, 14),
-  [670] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, 0, 0),
-  [672] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, 0, 0),
-  [674] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declaration, 6, 0, 14),
-  [676] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_declaration, 6, 0, 14),
-  [678] = {.entry = {.count = 1, .reusable = true}}, SHIFT(339),
-  [680] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [682] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
-  [684] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [686] = {.entry = {.count = 1, .reusable = true}}, SHIFT(340),
-  [688] = {.entry = {.count = 1, .reusable = true}}, SHIFT(341),
-  [690] = {.entry = {.count = 1, .reusable = false}}, SHIFT(198),
-  [692] = {.entry = {.count = 1, .reusable = false}}, SHIFT(202),
-  [694] = {.entry = {.count = 1, .reusable = false}}, SHIFT(197),
-  [696] = {.entry = {.count = 1, .reusable = false}}, SHIFT(217),
-  [698] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [700] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [702] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
-  [704] = {.entry = {.count = 1, .reusable = false}}, SHIFT(228),
-  [706] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
-  [708] = {.entry = {.count = 1, .reusable = false}}, SHIFT(182),
-  [710] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_charset_statement, 3, 0, 0),
-  [712] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_charset_statement, 3, 0, 0),
-  [714] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 3, 0, 0),
-  [716] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 3, 0, 0),
-  [718] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_at_rule, 3, 0, 0),
-  [720] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_at_rule, 3, 0, 0),
-  [722] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, 0, 0),
-  [724] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, 0, 0),
-  [726] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_at_rule, 4, 0, 0),
-  [728] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_at_rule, 4, 0, 0),
-  [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
-  [732] = {.entry = {.count = 1, .reusable = false}}, SHIFT(256),
-  [734] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_value, 1, 0, 0),
-  [736] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_value, 1, 0, 0),
-  [738] = {.entry = {.count = 1, .reusable = false}}, SHIFT(159),
-  [740] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_value, 1, 0, 0),
-  [742] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float_value, 1, 0, 0),
-  [744] = {.entry = {.count = 1, .reusable = false}}, SHIFT(160),
-  [746] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [748] = {.entry = {.count = 1, .reusable = false}}, SHIFT(165),
-  [750] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
-  [752] = {.entry = {.count = 1, .reusable = false}}, SHIFT(244),
-  [754] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [756] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [758] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
-  [760] = {.entry = {.count = 1, .reusable = false}}, SHIFT(183),
-  [762] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
-  [764] = {.entry = {.count = 1, .reusable = false}}, SHIFT(262),
-  [766] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [768] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [770] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
-  [772] = {.entry = {.count = 1, .reusable = false}}, SHIFT(274),
-  [774] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
-  [776] = {.entry = {.count = 1, .reusable = false}}, SHIFT(264),
-  [778] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_color_value, 2, 0, 0),
-  [780] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_color_value, 2, 0, 0),
-  [782] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_value, 2, 0, 0),
-  [784] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_value, 2, 0, 0),
-  [786] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_value, 2, 0, 0),
-  [788] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float_value, 2, 0, 0),
-  [790] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_call_expression, 2, 0, 7),
-  [792] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_call_expression, 2, 0, 7),
-  [794] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 2, 0, 0),
-  [796] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 2, 0, 0),
-  [798] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_grid_value, 3, 0, 0),
-  [800] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_grid_value, 3, 0, 0),
-  [802] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_value, 3, 0, 0),
-  [804] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parenthesized_value, 3, 0, 0),
-  [806] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_expression, 3, 0, 0),
-  [808] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_binary_expression, 3, 0, 0),
-  [810] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 3, 0, 0),
-  [812] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 3, 0, 0),
-  [814] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_grid_value, 4, 0, 0),
-  [816] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_grid_value, 4, 0, 0),
-  [818] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 4, 0, 0),
-  [820] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 4, 0, 0),
-  [822] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 1, 0, 0),
-  [824] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 1, 0, 0),
-  [826] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0),
-  [828] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
-  [830] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_last_declaration, 5, 0, 14),
-  [832] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 1, 0, 0),
-  [834] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 1, 0, 0),
-  [836] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [838] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [840] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
-  [842] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
-  [844] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [846] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
-  [848] = {.entry = {.count = 1, .reusable = false}}, SHIFT(111),
-  [850] = {.entry = {.count = 1, .reusable = false}}, SHIFT(257),
-  [852] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [854] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
-  [856] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [858] = {.entry = {.count = 1, .reusable = false}}, SHIFT(147),
-  [860] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
-  [862] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [864] = {.entry = {.count = 1, .reusable = true}}, SHIFT(335),
-  [866] = {.entry = {.count = 1, .reusable = true}}, SHIFT(324),
-  [868] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [870] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [872] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [874] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [876] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [878] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [880] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [882] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
-  [884] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_selectors_repeat1, 2, 0, 0),
-  [886] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_selectors, 1, 0, 0),
-  [888] = {.entry = {.count = 1, .reusable = false}}, SHIFT(152),
-  [890] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [892] = {.entry = {.count = 1, .reusable = false}}, SHIFT(205),
-  [894] = {.entry = {.count = 1, .reusable = false}}, SHIFT(221),
-  [896] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
-  [898] = {.entry = {.count = 1, .reusable = false}}, SHIFT(277),
-  [900] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [902] = {.entry = {.count = 1, .reusable = true}}, SHIFT(230),
-  [904] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
-  [906] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [908] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
-  [910] = {.entry = {.count = 1, .reusable = true}}, SHIFT(306),
-  [912] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
-  [914] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
-  [916] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
-  [918] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
-  [920] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [922] = {.entry = {.count = 1, .reusable = true}}, SHIFT(308),
-  [924] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [926] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keyframe_block_list_repeat1, 2, 0, 0),
-  [928] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keyframe_block_list_repeat1, 2, 0, 0), SHIFT_REPEAT(305),
-  [931] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keyframe_block_list_repeat1, 2, 0, 0), SHIFT_REPEAT(306),
-  [934] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
-  [936] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
-  [938] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
-  [940] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [942] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
-  [944] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
-  [946] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [948] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_query, 3, 0, 0),
-  [950] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_query, 3, 0, 0),
-  [952] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_feature_query, 5, 0, 16),
-  [954] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unary_query, 2, 0, 0),
-  [956] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_selector_query, 4, 0, 0),
-  [958] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_grid_value_repeat1, 2, 0, 0),
-  [960] = {.entry = {.count = 1, .reusable = false}}, SHIFT(303),
-  [962] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [964] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [966] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_import_statement_repeat1, 2, 0, 0),
-  [968] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
-  [970] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [972] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [974] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
-  [976] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
-  [978] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [980] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
-  [982] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [984] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
-  [986] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [988] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
-  [990] = {.entry = {.count = 1, .reusable = false}}, SHIFT(311),
-  [992] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [994] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
-  [996] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_selectors_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
-  [999] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyframe_block, 2, 0, 0),
-  [1001] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
-  [1003] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
-  [1005] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
-  [1007] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0), SHIFT_REPEAT(69),
-  [1010] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_import_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(207),
-  [1013] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [1015] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_grid_value_repeat1, 2, 0, 0), SHIFT_REPEAT(133),
-  [1018] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_selectors, 2, 0, 0),
-  [1020] = {.entry = {.count = 1, .reusable = true}}, SHIFT(251),
-  [1022] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_pseudo_class_arguments_repeat1, 2, 0, 0), SHIFT_REPEAT(13),
-  [1025] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
-  [1027] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
-  [1029] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
-  [1031] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
-  [1033] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [1035] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [1037] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [1039] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
-  [1041] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [1043] = {.entry = {.count = 1, .reusable = false}}, SHIFT(231),
-  [1045] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
-  [1047] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [1049] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
-  [1051] = {.entry = {.count = 1, .reusable = false}}, SHIFT(158),
-  [1053] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
-  [1055] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
-  [1057] = {.entry = {.count = 1, .reusable = false}}, SHIFT(342),
-  [1059] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [1061] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
-  [1063] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [1065] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
-  [1067] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [1069] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [1071] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
-  [1073] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [1075] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
-  [1077] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [1079] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [1081] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
-  [1083] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
-  [1085] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [1087] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [1089] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
-  [1091] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
-  [1093] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
-  [1095] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
-  [1097] = {.entry = {.count = 1, .reusable = false}}, SHIFT(358),
-  [1099] = {.entry = {.count = 1, .reusable = false}}, SHIFT(333),
-  [1101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [1103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [1105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [1107] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [1109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [1111] = {.entry = {.count = 1, .reusable = false}}, SHIFT(316),
-  [1113] = {.entry = {.count = 1, .reusable = false}}, SHIFT(317),
-  [1115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [1117] = {.entry = {.count = 1, .reusable = false}}, SHIFT(323),
-  [1119] = {.entry = {.count = 1, .reusable = false}}, SHIFT(328),
-  [1121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(329),
-  [1123] = {.entry = {.count = 1, .reusable = false}}, SHIFT(330),
-  [1125] = {.entry = {.count = 1, .reusable = false}}, SHIFT(331),
-  [1127] = {.entry = {.count = 1, .reusable = false}}, SHIFT(332),
-  [1129] = {.entry = {.count = 1, .reusable = false}}, SHIFT(359),
+  [474] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
+  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
+  [480] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
+  [482] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_arguments, 3, 0, 0),
+  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_arguments, 3, 0, 0),
+  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_selector, 3, 0, 0),
+  [490] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
+  [492] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_selector, 3, 0, 0),
+  [494] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_with_selector_arguments, 2, 0, 0),
+  [496] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_with_selector_arguments, 2, 0, 0),
+  [498] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_arguments, 2, 0, 0),
+  [500] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_arguments, 2, 0, 0),
+  [502] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 3, 0, 2),
+  [504] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 3, 0, 2),
+  [506] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__nth_child_pseudo_class_selector, 2, 0, 0),
+  [508] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__nth_child_pseudo_class_selector, 2, 0, 0),
+  [510] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_arguments, 2, 0, 0),
+  [512] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_arguments, 2, 0, 0),
+  [514] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 4, 0, 10),
+  [516] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 4, 0, 10),
+  [518] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_selector, 4, 0, 11),
+  [520] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_selector, 4, 0, 11),
+  [522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_selector, 4, 0, 15),
+  [524] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_selector, 4, 0, 15),
+  [526] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_with_selector_arguments, 3, 0, 0),
+  [528] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_with_selector_arguments, 3, 0, 0),
+  [530] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_nth_child_arguments, 3, 0, 0),
+  [532] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_nth_child_arguments, 3, 0, 0),
+  [534] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 2, 0, 0),
+  [536] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 2, 0, 0),
+  [538] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_selector, 3, 0, 5),
+  [540] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_selector, 3, 0, 5),
+  [542] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_arguments, 3, 0, 0),
+  [544] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_arguments, 3, 0, 0),
+  [546] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_selector, 5, 0, 9),
+  [548] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_selector, 5, 0, 9),
+  [550] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_selector, 3, 0, 9),
+  [552] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_selector, 3, 0, 9),
+  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_with_selector_arguments, 4, 0, 0),
+  [556] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_with_selector_arguments, 4, 0, 0),
+  [558] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_arguments, 4, 0, 0),
+  [560] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_arguments, 4, 0, 0),
+  [562] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_element_arguments, 4, 0, 0),
+  [564] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_element_arguments, 4, 0, 0),
+  [566] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute_selector, 6, 0, 15),
+  [568] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute_selector, 6, 0, 15),
+  [570] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_nth_child_arguments, 5, 0, 0),
+  [572] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_nth_child_arguments, 5, 0, 0),
+  [574] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_selector, 2, 0, 2),
+  [576] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_selector, 2, 0, 2),
+  [578] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_descendant_selector, 3, 0, 0),
+  [580] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_descendant_selector, 3, 0, 0),
+  [582] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_universal_selector, 1, 0, 0),
+  [584] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_universal_selector, 1, 0, 0),
+  [586] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pseudo_class_selector, 3, 0, 0),
+  [588] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pseudo_class_selector, 3, 0, 0),
+  [590] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_selector, 3, 0, 10),
+  [592] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_selector, 3, 0, 10),
+  [594] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_id_selector, 2, 0, 6),
+  [596] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_id_selector, 2, 0, 6),
+  [598] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_id_selector, 3, 0, 12),
+  [600] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_id_selector, 3, 0, 12),
+  [602] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_child_selector, 3, 0, 0),
+  [604] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_child_selector, 3, 0, 0),
+  [606] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_sibling_selector, 3, 0, 0),
+  [608] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_sibling_selector, 3, 0, 0),
+  [610] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_adjacent_sibling_selector, 3, 0, 0),
+  [612] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_adjacent_sibling_selector, 3, 0, 0),
+  [614] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_declaration, 6, 0, 14),
+  [616] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declaration, 6, 0, 14),
+  [618] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_statement, 5, 0, 0),
+  [620] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_import_statement, 5, 0, 0),
+  [622] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [624] = {.entry = {.count = 1, .reusable = false}}, SHIFT(180),
+  [626] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyframe_block_list, 3, 0, 0),
+  [628] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyframe_block_list, 3, 0, 0),
+  [630] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declaration, 4, 0, 14),
+  [632] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_declaration, 4, 0, 14),
+  [634] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
+  [636] = {.entry = {.count = 1, .reusable = false}}, SHIFT(226),
+  [638] = {.entry = {.count = 1, .reusable = false}}, SHIFT(280),
+  [640] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_declaration, 5, 0, 14),
+  [642] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_declaration, 5, 0, 14),
+  [644] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
+  [646] = {.entry = {.count = 1, .reusable = false}}, SHIFT(282),
+  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [650] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [652] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_postcss_statement, 3, 0, 0),
+  [654] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_postcss_statement, 3, 0, 0),
+  [656] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 4, 0, 0),
+  [658] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 4, 0, 0),
+  [660] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_at_rule, 2, 0, 0),
+  [662] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_at_rule, 2, 0, 0),
+  [664] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_statement, 3, 0, 0),
+  [666] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_import_statement, 3, 0, 0),
+  [668] = {.entry = {.count = 1, .reusable = true}}, SHIFT(346),
+  [670] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [672] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
+  [674] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [676] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
+  [678] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
+  [680] = {.entry = {.count = 1, .reusable = false}}, SHIFT(207),
+  [682] = {.entry = {.count = 1, .reusable = false}}, SHIFT(208),
+  [684] = {.entry = {.count = 1, .reusable = false}}, SHIFT(203),
+  [686] = {.entry = {.count = 1, .reusable = false}}, SHIFT(232),
+  [688] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
+  [690] = {.entry = {.count = 1, .reusable = false}}, SHIFT(250),
+  [692] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_rule_set, 2, 0, 0),
+  [694] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_rule_set, 2, 0, 0),
+  [696] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2, 0, 0),
+  [698] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2, 0, 0),
+  [700] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3, 0, 0),
+  [702] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3, 0, 0),
+  [704] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_media_statement, 3, 0, 0),
+  [706] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_media_statement, 3, 0, 0),
+  [708] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [710] = {.entry = {.count = 1, .reusable = false}}, SHIFT(188),
+  [712] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
+  [714] = {.entry = {.count = 1, .reusable = false}}, SHIFT(241),
+  [716] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_charset_statement, 3, 0, 0),
+  [718] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_charset_statement, 3, 0, 0),
+  [720] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 3, 0, 0),
+  [722] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 3, 0, 0),
+  [724] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyframes_statement, 3, 0, 8),
+  [726] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyframes_statement, 3, 0, 8),
+  [728] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_supports_statement, 3, 0, 0),
+  [730] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_supports_statement, 3, 0, 0),
+  [732] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_at_rule, 3, 0, 0),
+  [734] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_at_rule, 3, 0, 0),
+  [736] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_import_statement, 4, 0, 0),
+  [738] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_statement, 4, 0, 0),
+  [740] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_media_statement, 4, 0, 0),
+  [742] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_media_statement, 4, 0, 0),
+  [744] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 4, 0, 13),
+  [746] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 4, 0, 13),
+  [748] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyframe_block_list, 2, 0, 0),
+  [750] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyframe_block_list, 2, 0, 0),
+  [752] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_at_rule, 4, 0, 0),
+  [754] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_at_rule, 4, 0, 0),
+  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [758] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [760] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_value, 1, 0, 0),
+  [762] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_value, 1, 0, 0),
+  [764] = {.entry = {.count = 1, .reusable = false}}, SHIFT(169),
+  [766] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_value, 1, 0, 0),
+  [768] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float_value, 1, 0, 0),
+  [770] = {.entry = {.count = 1, .reusable = false}}, SHIFT(170),
+  [772] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [774] = {.entry = {.count = 1, .reusable = false}}, SHIFT(164),
+  [776] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
+  [778] = {.entry = {.count = 1, .reusable = false}}, SHIFT(274),
+  [780] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
+  [782] = {.entry = {.count = 1, .reusable = false}}, SHIFT(260),
+  [784] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
+  [786] = {.entry = {.count = 1, .reusable = false}}, SHIFT(270),
+  [788] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
+  [790] = {.entry = {.count = 1, .reusable = false}}, SHIFT(190),
+  [792] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
+  [794] = {.entry = {.count = 1, .reusable = false}}, SHIFT(268),
+  [796] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [798] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [800] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_expression, 3, 0, 0),
+  [802] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_binary_expression, 3, 0, 0),
+  [804] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_grid_value, 4, 0, 0),
+  [806] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_grid_value, 4, 0, 0),
+  [808] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 3, 0, 0),
+  [810] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 3, 0, 0),
+  [812] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 4, 0, 0),
+  [814] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 4, 0, 0),
+  [816] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_value, 2, 0, 0),
+  [818] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_value, 2, 0, 0),
+  [820] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_value, 2, 0, 0),
+  [822] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float_value, 2, 0, 0),
+  [824] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_call_expression, 2, 0, 7),
+  [826] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_call_expression, 2, 0, 7),
+  [828] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_color_value, 2, 0, 0),
+  [830] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_color_value, 2, 0, 0),
+  [832] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_grid_value, 3, 0, 0),
+  [834] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_grid_value, 3, 0, 0),
+  [836] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_value, 3, 0, 0),
+  [838] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parenthesized_value, 3, 0, 0),
+  [840] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments, 2, 0, 0),
+  [842] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 2, 0, 0),
+  [844] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [846] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_last_declaration, 5, 0, 14),
+  [848] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_declaration_repeat1, 1, 0, 0),
+  [850] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 1, 0, 0),
+  [852] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_postcss_statement_repeat1, 1, 0, 0),
+  [854] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_postcss_statement_repeat1, 1, 0, 0),
+  [856] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_declaration_repeat1, 2, 0, 0),
+  [858] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [860] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [862] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [864] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [866] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [868] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [870] = {.entry = {.count = 1, .reusable = false}}, SHIFT(109),
+  [872] = {.entry = {.count = 1, .reusable = false}}, SHIFT(266),
+  [874] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [876] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [878] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [880] = {.entry = {.count = 1, .reusable = false}}, SHIFT(158),
+  [882] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [884] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_selectors, 1, 0, 0),
+  [886] = {.entry = {.count = 1, .reusable = true}}, SHIFT(348),
+  [888] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
+  [890] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [892] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [894] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [896] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [898] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [900] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [902] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
+  [904] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [906] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_selectors_repeat1, 2, 0, 0),
+  [908] = {.entry = {.count = 1, .reusable = false}}, SHIFT(104),
+  [910] = {.entry = {.count = 1, .reusable = false}}, SHIFT(139),
+  [912] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [914] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [916] = {.entry = {.count = 1, .reusable = false}}, SHIFT(210),
+  [918] = {.entry = {.count = 1, .reusable = false}}, SHIFT(222),
+  [920] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
+  [922] = {.entry = {.count = 1, .reusable = false}}, SHIFT(283),
+  [924] = {.entry = {.count = 1, .reusable = false}}, SHIFT(317),
+  [926] = {.entry = {.count = 1, .reusable = false}}, SHIFT(320),
+  [928] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [930] = {.entry = {.count = 1, .reusable = false}}, SHIFT(315),
+  [932] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [934] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [936] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
+  [938] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
+  [940] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [942] = {.entry = {.count = 1, .reusable = true}}, SHIFT(311),
+  [944] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
+  [946] = {.entry = {.count = 1, .reusable = true}}, SHIFT(316),
+  [948] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
+  [950] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [952] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
+  [954] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [956] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [958] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
+  [960] = {.entry = {.count = 1, .reusable = false}}, SHIFT(120),
+  [962] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [964] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keyframe_block_list_repeat1, 2, 0, 0),
+  [966] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keyframe_block_list_repeat1, 2, 0, 0), SHIFT_REPEAT(311),
+  [969] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keyframe_block_list_repeat1, 2, 0, 0), SHIFT_REPEAT(312),
+  [972] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [974] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
+  [976] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
+  [978] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [980] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [982] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_grid_value_repeat1, 2, 0, 0),
+  [984] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_query, 3, 0, 0),
+  [986] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unary_query, 2, 0, 0),
+  [988] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_query, 3, 0, 0),
+  [990] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_selector_query, 4, 0, 0),
+  [992] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_feature_query, 5, 0, 16),
+  [994] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [996] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
+  [998] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [1000] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
+  [1002] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [1004] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [1006] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
+  [1008] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [1010] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
+  [1012] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [1014] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
+  [1016] = {.entry = {.count = 1, .reusable = true}}, SHIFT(318),
+  [1018] = {.entry = {.count = 1, .reusable = false}}, SHIFT(299),
+  [1020] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
+  [1022] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_import_statement_repeat1, 2, 0, 0),
+  [1024] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [1026] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
+  [1028] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyframe_block, 2, 0, 0),
+  [1030] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
+  [1032] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
+  [1035] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_import_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(213),
+  [1038] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_selectors_repeat1, 2, 0, 0), SHIFT_REPEAT(43),
+  [1041] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
+  [1043] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [1045] = {.entry = {.count = 1, .reusable = false}}, SHIFT(235),
+  [1047] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [1049] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_pseudo_class_arguments_repeat1, 2, 0, 0), SHIFT_REPEAT(13),
+  [1052] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_grid_value_repeat1, 2, 0, 0), SHIFT_REPEAT(147),
+  [1055] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
+  [1057] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
+  [1059] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [1061] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_selectors, 2, 0, 0),
+  [1063] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [1065] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
+  [1067] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [1069] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [1071] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [1073] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
+  [1075] = {.entry = {.count = 1, .reusable = false}}, SHIFT(246),
+  [1077] = {.entry = {.count = 1, .reusable = false}}, SHIFT(91),
+  [1079] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [1081] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [1083] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [1085] = {.entry = {.count = 1, .reusable = true}}, SHIFT(258),
+  [1087] = {.entry = {.count = 1, .reusable = true}}, SHIFT(279),
+  [1089] = {.entry = {.count = 1, .reusable = false}}, SHIFT(172),
+  [1091] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
+  [1093] = {.entry = {.count = 1, .reusable = false}}, SHIFT(328),
+  [1095] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [1097] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [1099] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
+  [1101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
+  [1103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
+  [1105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [1107] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [1109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [1111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
+  [1113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(285),
+  [1115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [1117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [1119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
+  [1121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(369),
+  [1123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [1125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
+  [1127] = {.entry = {.count = 1, .reusable = false}}, SHIFT(325),
+  [1129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [1131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(323),
+  [1133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [1135] = {.entry = {.count = 1, .reusable = false}}, SHIFT(330),
+  [1137] = {.entry = {.count = 1, .reusable = false}}, SHIFT(336),
+  [1139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [1141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [1143] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [1145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [1147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [1149] = {.entry = {.count = 1, .reusable = false}}, SHIFT(327),
+  [1151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [1153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [1155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [1157] = {.entry = {.count = 1, .reusable = false}}, SHIFT(339),
+  [1159] = {.entry = {.count = 1, .reusable = false}}, SHIFT(340),
+  [1161] = {.entry = {.count = 1, .reusable = false}}, SHIFT(341),
+  [1163] = {.entry = {.count = 1, .reusable = false}}, SHIFT(342),
+  [1165] = {.entry = {.count = 1, .reusable = false}}, SHIFT(343),
+  [1167] = {.entry = {.count = 1, .reusable = false}}, SHIFT(370),
 };
 
 enum ts_external_scanner_symbol_identifiers {

--- a/test/corpus/selectors.txt
+++ b/test/corpus/selectors.txt
@@ -83,6 +83,8 @@ p:has(li.foo) {}
 *:where(li#foo) {}
 p:has(.foo, .bar) {}
 a:not([href]) {}
+:host([a="b"]:hover) {}
+:nth-child(2n of a.external) {}
 ---
 
 (stylesheet
@@ -109,7 +111,47 @@ a:not([href]) {}
     (block))
   (rule_set
     (selectors (pseudo_class_selector (tag_name) (class_name) (arguments (attribute_selector (attribute_name)))))
-    (block)))
+    (block))
+  (rule_set
+    (selectors (pseudo_class_selector (class_name) (arguments (pseudo_class_selector (attribute_selector (attribute_name) (string_value)) (class_name)))))
+    (block))
+  (rule_set
+    (selectors (pseudo_class_selector (class_name) (arguments (plain_value) (class_selector (tag_name) (class_name)))))
+    (block))
+)
+
+=========================
+:nth-child and :nth-last-child selectors
+=========================
+
+:nth-child(2) {}
+:nth-last-child(-n) {}
+:nth-last-child(2n+1) {}
+:nth-child(2n + 2) {}
+:nth-last-child(-n) {}
+:nth-child(2n of a.external) {}
+---
+
+(stylesheet
+  (rule_set
+    (selectors (pseudo_class_selector (class_name) (arguments (integer_value))))
+    (block))
+  (rule_set
+    (selectors (pseudo_class_selector (class_name) (arguments (plain_value))))
+    (block))
+  (rule_set
+    (selectors (pseudo_class_selector (class_name) (arguments (plain_value))))
+    (block))
+  (rule_set
+    (selectors (pseudo_class_selector (class_name) (arguments (plain_value))))
+    (block))
+  (rule_set
+    (selectors (pseudo_class_selector (class_name) (arguments (plain_value))))
+    (block))
+  (rule_set
+    (selectors (pseudo_class_selector (class_name) (arguments (plain_value) (class_selector (tag_name) (class_name)))))
+    (block))
+)
 
 =========================
 Pseudo-element selectors


### PR DESCRIPTION
…as well as `:nth-child` and `:nth-last-child`.

Fixes #57.

This was prompted by #57 and I wanted to fix it while it was still in my head. I got bitten by the other thing that this PR fixes…

```css
:nth-last-child(-n + 3 of li.important) {}
```

…where `li.important` is parsed as a `plain_value` instead of as a `selector`.

This is another quick fix that avoids a larger reckoning with pseudoclass arguments. It's hard to say whether the CSS spec has any sort of predictable limitation in mind for what can be a valid argument to a pseudoclass; the ones we've whitelisted are those that take CSS selectors, but among the others it's generally a one-off set of valid values that varies per pseudoclass. For example:

* [:state()](https://developer.mozilla.org/en-US/docs/Web/CSS/:state)’s argument is a custom state defined by a custom element — something we can't know, but which is probably constrained similarly to a JS identifier (begins with ASCII, no spaces, etc.)
* [:lang()](https://developer.mozilla.org/en-US/docs/Web/CSS/:lang)’s argument is a language or locale code (`en`, `en-US`)
* [:dir()](https://developer.mozilla.org/en-US/docs/Web/CSS/:dir)’s is either `rtl` or `ltr`
* [:nth-of-type()](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type) has similar syntax to `:nth-child`, but without the optional filtering selector that the latter has — `even`, `odd`, `4`, `-n`, `2n+1` are all valid values

In theory, we could get away with a minimal approach:

* Pseudoclass arguments that are obviously selectors get parsed as such
* All other text inside a pseudoclass’s parentheses is parsed as `plain_value`

In practice, we go a bit further than this; for instance, I think the `4` in `:nth-child(4)` would get parsed as an `integer_value`, which is fine.

As I describe in #57, the holy grail here would be to prevent `plain_value` from precluding selector detection while lexing, but I haven't figured that out yet. Until we do, the best approach is to manually handle each pseudoclass that can take a selector to prevent scenarios where both `selector` and `plain_value` are valid lexing options.

---

I forget what the right hygiene is these days around committing generated files, so let me know if I've done this wrong and I'll amend it.