### PR TITLE
Parse nested selectors ending with `&`

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -35,7 +35,7 @@ bool tree_sitter_css_external_scanner_scan(void *payload, TSLexer *lexer, const 
         lexer->mark_end(lexer);
 
         if (lexer->lookahead == '#' || lexer->lookahead == '.' || lexer->lookahead == '[' || lexer->lookahead == '-' ||
-            lexer->lookahead == '*' || iswalnum(lexer->lookahead)) {
+            lexer->lookahead == '*' || lexer->lookahead == '&' || iswalnum(lexer->lookahead)) {
             return true;
         }
 

--- a/test/corpus/selectors.txt
+++ b/test/corpus/selectors.txt
@@ -249,6 +249,7 @@ a {
   &.b {}
   & c {}
   & > d {}
+  e & {}
 }
 
 ---
@@ -259,7 +260,8 @@ a {
     (block
       (rule_set (selectors (class_selector (nesting_selector) (class_name (identifier)))) (block))
       (rule_set (selectors (descendant_selector (nesting_selector) (tag_name))) (block))
-      (rule_set (selectors (child_selector (nesting_selector) (tag_name))) (block)))))
+      (rule_set (selectors (child_selector (nesting_selector) (tag_name))) (block))
+      (rule_set (selectors (descendant_selector (tag_name) (nesting_selector))) (block)))))
 
 ===========================
 Sibling selectors


### PR DESCRIPTION
More precisely, allow the nesting selector to follow the descendant combinator, thereby allowing this syntax:

```css
a {
  b & {}
}
```

[MDN documentation of this feature can be found here](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Nesting_selector#appending_the_nesting_selector)